### PR TITLE
Fixed accessApi constant in config.ts

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -29,7 +29,7 @@ export function getConfig() {
 
   const port = process.env.PORT || defaultPort;
 
-  const accessApi = process.env.FLOW_ACCESS_NODE;
+  const accessApi = process.env.FLOW_ACCESS_API;
 
   const minterAddress = fcl.withPrefix(process.env.MINTER_ADDRESS!);
   const minterPrivateKeyHex = process.env.MINTER_PRIVATE_KEY!;


### PR DESCRIPTION
Mistyped variable name fixed.
This error caused https://github.com/onflow/kitty-items/issues/76 and fresh installs following the tutorial was not possible.
We can also fix this by replacing the variable name in .env file