### PR TITLE
Refactor arguments

### DIFF
--- a/cadence/lib/js/package.json
+++ b/cadence/lib/js/package.json
@@ -21,7 +21,7 @@
     "@babel/preset-env": "^7.14.1",
     "@onflow/types": "^0.0.4",
     "babel-jest": "^26.6.3",
-    "flow-js-testing": "^0.1.10",
+    "flow-js-testing": "^0.1.11",
     "jest": "^26.6.3",
     "prettier": "^2.3.0"
   }

--- a/cadence/lib/js/src/kibble.js
+++ b/cadence/lib/js/src/kibble.js
@@ -1,10 +1,7 @@
-import { Address, UFix64 } from "@onflow/types";
 import {
 	deployContractByName,
 	executeScript,
 	getContractAddress,
-	getScriptCode,
-	getTransactionCode,
 	mintFlow,
 	sendTransaction,
 } from "flow-js-testing";
@@ -50,7 +47,7 @@ export const getKibbleBalance = async (account) => {
 
 	const name = "kibble/get_balance";
 	const addressMap = { Kibble: KittyAdmin };
-	const args = [[account, Address]];
+	const args = [account];
 
 	return executeScript({ name, addressMap, args });
 };
@@ -81,10 +78,7 @@ export const mintKibble = async (recipient, amount) => {
 
 	const name = "kibble/mint_tokens";
 	const addressMap = { Kibble: KittyAdmin };
-	const args = [
-		[recipient, Address],
-		[amount, UFix64],
-	];
+	const args = [recipient, amount];
 	const signers = [KittyAdmin];
 
 	return sendTransaction({ name, addressMap, args, signers });
@@ -103,10 +97,7 @@ export const transferKibble = async (sender, recipient, amount) => {
 
 	const name = "kibble/transfer_tokens";
 	const addressMap = { Kibble: KittyAdmin };
-	const args = [
-		[amount, UFix64],
-		[recipient, Address],
-	];
+	const args = [amount, recipient];
 	const signers = [sender];
 
 	return sendTransaction({ name, addressMap, args, signers });

--- a/cadence/lib/js/src/kitty-items-marketplace.js
+++ b/cadence/lib/js/src/kitty-items-marketplace.js
@@ -1,9 +1,7 @@
-import { UFix64, UInt64, Address } from "@onflow/types";
 import {
 	getContractAddress,
 	deployContractByName,
 	getTransactionCode,
-	getScriptCode,
 	executeScript,
 	sendTransaction,
 } from "flow-js-testing";
@@ -71,10 +69,7 @@ export const listItemForSale = async (seller, itemId, price) => {
 	};
 
 	const name = "kittyItemsMarket/sell_market_item";
-	const args = [
-		[itemId, UInt64],
-		[price, UFix64],
-	];
+	const args = [itemId, price];
 	const signers = [seller];
 
 	return sendTransaction({ name, addressMap, args, signers });
@@ -99,10 +94,7 @@ export const buyItem = async (buyer, itemId, seller) => {
 	};
 
 	const name = "kittyItemsMarket/buy_market_item";
-	const args = [
-		[itemId, UInt64],
-		[seller, Address],
-	];
+	const args = [itemId, seller];
 	const signers = [buyer];
 
 	return sendTransaction({ name, addressMap, args, signers });
@@ -123,7 +115,7 @@ export const removeItem = async (owner, itemId) => {
 
 	const code = await getTransactionCode({ name, addressMap });
 	const signers = [owner];
-	const args = [[itemId, UInt64]];
+	const args = [itemId];
 
 	return sendTransaction({ code, args, signers });
 };
@@ -139,7 +131,7 @@ export const getMarketCollectionLength = async (account) => {
 
 	const name = "kittyItemsMarket/read_collection_length";
 	const addressMap = { KittyItemsMarket };
-	const args = [[account, account, Address]];
+	const args = [account, account];
 
 	return executeScript({ name, addressMap, args });
 };

--- a/cadence/lib/js/src/kitty-items.js
+++ b/cadence/lib/js/src/kitty-items.js
@@ -1,13 +1,4 @@
-import { Address, UInt64 } from "@onflow/types";
-import {
-	deployContractByName,
-	executeScript,
-	getContractAddress,
-	getScriptCode,
-	getTransactionCode,
-	mintFlow,
-	sendTransaction,
-} from "flow-js-testing";
+import { deployContractByName, executeScript, getContractAddress, mintFlow, sendTransaction } from "flow-js-testing";
 
 import { getKittyAdminAddress } from "./common";
 
@@ -76,14 +67,10 @@ export const mintKittyItem = async (itemType, recipient) => {
 
 	const name = "kittyItems/mint_kitty_item";
 	const addressMap = { NonFungibleToken, KittyItems };
-
+	const args = [recipient, itemType];
 	const signers = [KittyAdmin];
-	const args = [
-		[recipient, Address],
-		[itemType, UInt64],
-	];
 
-	return sendTransaction({ name, addressMap, signers, args });
+	return sendTransaction({ name, addressMap, args, signers });
 };
 
 /*
@@ -100,10 +87,7 @@ export const transferKittyItem = async (sender, recipient, itemId) => {
 
 	const name = "kittyItems/transfer_kitty_item";
 	const addressMap = { NonFungibleToken, KittyItems };
-	const args = [
-		[recipient, Address],
-		[itemId, UInt64],
-	];
+	const args = [recipient, itemId];
 	const signers = [sender];
 
 	return sendTransaction({ name, addressMap, args, signers });
@@ -122,10 +106,7 @@ export const getKittyItemById = async (account, id) => {
 
 	const name = "kittyItems/read_kitty_item_type_id";
 	const addressMap = { KittyItems, NonFungibleToken };
-	const args = [
-		[account, Address],
-		[id, UInt64],
-	];
+	const args = [account, id];
 
 	return executeScript({ name, addressMap, args });
 };
@@ -142,7 +123,7 @@ export const getCollectionLength = async (account) => {
 
 	const name = "kittyItems/read_collection_length";
 	const addressMap = { NonFungibleToken, KittyItems };
-	const args = [[account, Address]];
+	const args = [account];
 
 	return executeScript({ name, addressMap, args });
 };

--- a/cadence/lib/js/test/kibble.test.js
+++ b/cadence/lib/js/test/kibble.test.js
@@ -62,7 +62,7 @@ describe("Kibble", () => {
 		await setupKibbleOnAccount(Alice);
 
 		// Mint instruction with amount equal to 0 shall be reverted
-		const result = await shallRevert(mintKibble(Alice, toUFix64(0)));
+		await shallRevert(mintKibble(Alice, toUFix64(0)));
 	});
 
 	it("shall mint tokens, deposit, and update balance and total supply", async () => {

--- a/cadence/lib/js/test/kitty-items-marketplace.test.js
+++ b/cadence/lib/js/test/kitty-items-marketplace.test.js
@@ -1,5 +1,5 @@
 import path from "path";
-import { init, getAccountAddress, emulator, shallPass } from "flow-js-testing";
+import { emulator, init, getAccountAddress, shallPass } from "flow-js-testing";
 
 import { toUFix64 } from "../src/common";
 import { mintKibble } from "../src/kibble";

--- a/cadence/lib/js/test/kitty-items.test.js
+++ b/cadence/lib/js/test/kitty-items.test.js
@@ -1,5 +1,5 @@
 import path from "path";
-import { init, emulator, getAccountAddress, shallPass, shallResolve, shallRevert } from "flow-js-testing";
+import { emulator, init, getAccountAddress, shallPass, shallResolve, shallRevert } from "flow-js-testing";
 
 import {
 	deployKittyItems,


### PR DESCRIPTION
With updated version of `flow-js-testing` it will be possible to pass just the values of arguments, without specifying their types - which will be inferred from Cadence code.