### PR TITLE
use fetchFUSDBalance instead of fetchKibblesBalance

### DIFF
--- a/web/src/hooks/use-fusd-balance.hook.js
+++ b/web/src/hooks/use-fusd-balance.hook.js
@@ -6,7 +6,7 @@ export const valueAtom = atomFamily({
   key: "fusd-balance::state",
   default: selectorFamily({
     key: "fusd-balance::default",
-    get: address => async () => fetchKibblesBalance(address),
+    get: address => async () => fetchFUSDBalance(address),
   }),
 })
 
@@ -21,7 +21,7 @@ export function useFUSDBalance(address) {
 
   async function refresh() {
     setStatus(PROCESSING)
-    await fetchKibblesBalance(address).then(setBalance)
+    await fetchFUSDBalance(address).then(setBalance)
     setStatus(IDLE)
   }
 
@@ -41,7 +41,7 @@ export function useFUSDBalance(address) {
           amount: 50.0,
         }),
       })
-      await fetchKibblesBalance(address).then(setBalance)
+      await fetchFUSDBalance(address).then(setBalance)
       setStatus(IDLE)
     },
   }


### PR DESCRIPTION
I think the last merge of the FUSD branch broke the balance hook. 
This PR fixes this issue by using the proper function calls.