### PR TITLE
Add missing allowedAmount parameter

### DIFF
--- a/cadence/transactions/flow/mint_tokens.cdc
+++ b/cadence/transactions/flow/mint_tokens.cdc
@@ -18,7 +18,7 @@ transaction(recipient: Address, amount: UFix64) {
     }
 
     execute {
-        let minter <- self.tokenAdmin.createNewMinter()
+        let minter <- self.tokenAdmin.createNewMinter(allowedAmount: amount)
         let mintedVault <- minter.mintTokens(amount: amount)
 
         self.tokenReceiver.deposit(from: <-mintedVault)


### PR DESCRIPTION
The return type of FlowToken's mintTokens was `FlowToken.Vault`.

However, deposit function input parameter is `FungibleToken.Vault`. I thought this was meant to be, so I edited it.