### PR TITLE
replace legacy fcl.send() methods with latest best practice

### DIFF
--- a/api/src/services/flow.ts
+++ b/api/src/services/flow.ts
@@ -65,24 +65,28 @@ class FlowService {
     payer,
     skipSeal
   }: any): Promise<any> => {
-    const response = await fcl.send([
-      fcl.transaction`
-        ${transaction}
-      `,
-      fcl.args(args),
-      fcl.proposer(proposer),
-      fcl.authorizations(authorizations),
-      fcl.payer(payer),
-      fcl.limit(9999),
-    ]);
+    const response = await fcl.mutate(
+      {
+        cadence: transaction,
+        args: (_arg, _t) => args,
+        proposer,
+        authorizations,
+        payer,
+        limit: 9999,
+      },
+    )
 
     if (skipSeal) return response;
     return await fcl.tx(response).onceSealed();
   };
 
   async executeScript<T>({ script, args }): Promise<T> {
-    const response = await fcl.send([fcl.script`${script}`, fcl.args(args)]);
-    return await fcl.decode(response);
+    return await fcl.query(
+      {
+        cadence: script,
+        args: (_arg, _t) => args,
+      },
+    );
   }
 
   async getLatestBlockHeight() {

--- a/web/src/flow/script.get-account-items.js
+++ b/web/src/flow/script.get-account-items.js
@@ -2,7 +2,7 @@ import * as fcl from "@onflow/fcl"
 import {Address} from "@onflow/types"
 import {expandAccountItemsKey} from "src/hooks/useAccountItems"
 
-const CODE = fcl.cdc`
+const FETCH_ACCOUNT_ITEMS_SCRIPT = `
   import NonFungibleToken from 0xNonFungibleToken
   import KittyItems from 0xKittyItems
 
@@ -20,10 +20,10 @@ export function fetchAccountItems(key) {
   if (address == null) return Promise.resolve([])
 
   // prettier-ignore
-  return fcl.send([
-    fcl.script(CODE),
-    fcl.args([
-      fcl.arg(address, Address)
-    ]),
-  ]).then(fcl.decode).then(d => d.sort((a, b) => a - b))
+  return fcl.query({
+    cadence: FETCH_ACCOUNT_ITEMS_SCRIPT,
+    args: (arg, t) => [
+      fcl.arg(address, Address),
+    ],
+  })
 }

--- a/web/src/flow/tx.create-listing.js
+++ b/web/src/flow/tx.create-listing.js
@@ -1,8 +1,6 @@
-import * as fcl from "@onflow/fcl"
-import * as t from "@onflow/types"
 import {tx} from "src/flow/util/tx"
 
-const CODE = fcl.cdc`
+const CREATE_LISTING_TRANSACTION = `
   import FungibleToken from 0xFungibleToken
   import NonFungibleToken from 0xNonFungibleToken
   import FlowToken from 0xFlowToken
@@ -72,19 +70,15 @@ export function createListing({itemID, price}, opts = {}) {
     throw new Error("createListing(itemID, price) -- itemID required")
   if (price == null)
     throw new Error("createListing(itemID, price) -- price required")
-
-  // prettier-ignore
-  return tx([
-    fcl.transaction(CODE),
-    fcl.args([
-      fcl.arg(Number(itemID), t.UInt64),
-      fcl.arg(String(price.toFixed(2)), t.UFix64),
-    ]),
-    fcl.proposer(fcl.authz),
-    fcl.payer(fcl.authz),
-    fcl.authorizations([
-      fcl.authz
-    ]),
-    fcl.limit(1000)
-  ], opts)
+  return tx(
+    {
+      cadence: CREATE_LISTING_TRANSACTION,
+      args: (arg, t) => [
+        arg(Number(itemID), t.UInt64),
+        arg(String(price.toFixed(2)), t.UFix64),
+      ],
+      limit: 1000,
+    },
+    opts,
+  )
 }

--- a/web/src/flow/tx.initialize-account.js
+++ b/web/src/flow/tx.initialize-account.js
@@ -1,9 +1,8 @@
 // prettier-ignore
-import { authorizations, authz, cdc, limit, payer, proposer, transaction } from "@onflow/fcl"
 import {invariant} from "@onflow/util-invariant"
 import {tx} from "src/flow/util/tx"
 
-const CODE = cdc`
+const INITIALIZE_ACCOUNT_TRANSACTION = `
   import FungibleToken from 0xFungibleToken
   import NonFungibleToken from 0xNonFungibleToken
   import KittyItems from 0xKittyItems
@@ -45,15 +44,11 @@ const CODE = cdc`
 export async function initializeAccount(address, opts = {}) {
   // prettier-ignore
   invariant(address != null, "Tried to initialize an account but no address was supplied")
-
   return tx(
-    [
-      transaction(CODE),
-      limit(70),
-      proposer(authz),
-      payer(authz),
-      authorizations([authz]),
-    ],
-    opts
+    {
+      cadence: INITIALIZE_ACCOUNT_TRANSACTION,
+      limit: 70,
+    },
+    opts,
   )
 }

--- a/web/src/flow/tx.purchase-listing.js
+++ b/web/src/flow/tx.purchase-listing.js
@@ -1,9 +1,7 @@
-import * as fcl from "@onflow/fcl"
-import * as t from "@onflow/types"
 import {invariant} from "@onflow/util-invariant"
 import {tx} from "src/flow/util/tx"
 
-const CODE = fcl.cdc`
+const PURCHASE_LISTING_TRANSACTION = `
   import FungibleToken from 0xFungibleToken
   import NonFungibleToken from 0xNonFungibleToken
   import FlowToken from 0xFlowToken
@@ -73,15 +71,15 @@ export function purchaseListing({itemID, ownerAddress}, opts = {}) {
   invariant(itemID != null, "buyMarketItem({itemID, ownerAddress}) -- itemID required")
   invariant(ownerAddress != null, "buyMarketItem({itemID, ownerAddress}) -- ownerAddress required")
 
-  return tx([
-    fcl.transaction(CODE),
-    fcl.args([
-      fcl.arg(Number(itemID), t.UInt64),
-      fcl.arg(String(ownerAddress), t.Address),
-    ]),
-    fcl.proposer(fcl.authz),
-    fcl.payer(fcl.authz),
-    fcl.authorizations([fcl.authz]),
-    fcl.limit(1000),
-  ], opts)
+  return tx(
+    {
+      cadence: PURCHASE_LISTING_TRANSACTION,
+      args: (arg, t) => [
+        arg(itemID, t.UInt64),
+        arg(ownerAddress, t.Address)
+      ],
+      limit: 1000,
+    },
+    opts,
+  )
 }

--- a/web/src/flow/tx.remove-listing.js
+++ b/web/src/flow/tx.remove-listing.js
@@ -1,9 +1,7 @@
-import * as fcl from "@onflow/fcl"
-import * as t from "@onflow/types"
 import {invariant} from "@onflow/util-invariant"
 import {tx} from "src/flow/util/tx"
 
-const CODE = fcl.cdc`
+const REMOVE_LISTING_TRANSACTION = `
   import NFTStorefront from 0xNFTStorefront
 
   transaction(listingResourceID: UInt64) {
@@ -26,16 +24,14 @@ export function removeListing({listingResourceID}, opts = {}) {
     listingResourceID != null,
     "cancelMarketListing({listingResourceID}) -- listingResourceID required"
   )
-
   return tx(
-    [
-      fcl.transaction(CODE),
-      fcl.args([fcl.arg(Number(listingResourceID), t.UInt64)]),
-      fcl.proposer(fcl.authz),
-      fcl.payer(fcl.authz),
-      fcl.authorizations([fcl.authz]),
-      fcl.limit(1000),
-    ],
-    opts
+    {
+      cadence: REMOVE_LISTING_TRANSACTION, 
+      args: (arg, t) => [
+        arg(listingResourceID, t.UInt64),
+      ],
+      limit: 1000,
+    },
+    opts,
   )
 }

--- a/web/src/flow/util/tx.js
+++ b/web/src/flow/util/tx.js
@@ -12,7 +12,14 @@ export async function tx(mods = [], opts = {}) {
 
   try {
     onStart()
-    var txId = await fcl.send(mods).then(fcl.decode)
+    var txId = await fcl.mutate({
+      cadence: mods.cadence,
+      args: mods.args,
+      payer: mods.payer,
+      proposer: mods.proposer,
+      authorizations: mods.authorizations,
+      limit: mods.limit,
+    })
     console.info(
       `%cTX[${txId}]: ${fvsTx(await fcl.config().get("env"), txId)}`,
       "color:purple;font-weight:bold;font-family:monospace;"

--- a/web/src/hooks/useMintAndList.js
+++ b/web/src/hooks/useMintAndList.js
@@ -38,7 +38,7 @@ export default function useMintAndList(onSuccess) {
       onSuccess: async data => {
         setIsMintingLoading(true)
 
-        const transactionId = data?.transaction?.transactionId
+        const transactionId = data?.transaction
         if (!transactionId) throw "Missing transactionId"
 
         const unsub = await fcl


### PR DESCRIPTION
## context
FCL has been evolving and introduced various convenient wrapper functions (i.e. mutate and query). We would like to keep KittyItems code base up-to-date by following the latest FCL best practice. 
The goal of this PR is to replace all legacy fcl.send() methods with fcl.mutate and fcl.query wherever applicable 

## tests
- verified minting KittyItems work
- verified adding a listing and removing a listing works
- verified purchasing a KittyItem works
- checked both FE and BE logs to ensure there are no new errors introduced