### PR TITLE
fix broken Cadence tests

### DIFF
--- a/.github/workflows/integration-local.yml
+++ b/.github/workflows/integration-local.yml
@@ -31,10 +31,9 @@ jobs:
       - name: Root NPM Install
         run: npm i && npx lerna exec npm install
 
-      # Not working. See issue: https://github.com/onflow/flow-js-testing/issues/47
-      # - name: Run JS Tests
-      #   run: npx jest
-      #   working-directory: cadence/tests/js
+      - name: Run JS Tests
+        run: npm i && npm run test
+        working-directory: cadence/tests
 
       - name: Build & Run
         run: npm run start:dev

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ We love decentralization, but servers are still very useful, and this one's no e
 
 ### 3. Cadence Code | [kitty-items/cadence](https://github.com/onflow/kitty-items/tree/master/cadence)
 
-[Cadence](https://docs.onflow.org/cadence) smart contracts, scripts & transactions for your viewing pleasure. This folder contains all of the blockchain logic for the marketplace application. Here you will find examples of [fungible token](https://github.com/onflow/flow-ft) and [non-fungible token (NFT)](https://github.com/onflow/flow-nft) smart contract implementations, as well as the scripts and transactions that interact with them. It also contains examples of how to _test_ your Cadence code (tests written in Golang).
+[Cadence](https://docs.onflow.org/cadence) smart contracts, scripts & transactions for your viewing pleasure. This folder contains all of the blockchain logic for the marketplace application. Here you will find examples of [fungible token](https://github.com/onflow/flow-ft) and [non-fungible token (NFT)](https://github.com/onflow/flow-nft) smart contract implementations, as well as the scripts and transactions that interact with them. It also contains examples of how to _test_ your Cadence code.
 
 ## 😺 What are Kitty Items?
 

--- a/cadence/tests/test/kitty-items.test.js
+++ b/cadence/tests/test/kitty-items.test.js
@@ -30,12 +30,14 @@ describe("Kitty Items", () => {
 		const basePath = path.resolve(__dirname, "../../");
 		const port = 7002;
 		await init(basePath, { port });
-		return emulator.start(port, false);
+		await emulator.start(port, false);
+		return await new Promise(r => setTimeout(r, 1000));
 	});
 
 	// Stop emulator, so it could be restarted
 	afterEach(async () => {
-		return emulator.stop();
+		await emulator.stop();
+		return await new Promise(r => setTimeout(r, 1000));
 	});
 
 	it("shall deploy KittyItems contract", async () => {

--- a/cadence/tests/test/nft-storefront.test.js
+++ b/cadence/tests/test/nft-storefront.test.js
@@ -18,9 +18,9 @@ import {
 } from "../src/kitty-items";
 import {
 	deployNFTStorefront,
-	buyItem,
-	sellItem,
-	removeItem,
+	purchaseItemListing,
+	createItemListing,
+	removeItemListing,
 	setupStorefrontOnAccount,
 	getListingCount,
 } from "../src/nft-storefront";
@@ -33,12 +33,14 @@ describe("NFT Storefront", () => {
 		const basePath = path.resolve(__dirname, "../../");
 		const port = 7003;
 		await init(basePath, { port });
-		return emulator.start(port, false);
+		await emulator.start(port, false);
+		return await new Promise(r => setTimeout(r, 1000));
 	});
 
 	// Stop emulator, so it could be restarted
 	afterEach(async () => {
-		return emulator.stop();
+		await emulator.stop();
+		return await new Promise(r => setTimeout(r, 1000));
 	});
 
 	it("shall deploy NFTStorefront contract", async () => {
@@ -64,7 +66,7 @@ describe("NFT Storefront", () => {
 
 		const itemID = 0;
 
-		await shallPass(sellItem(Alice, itemID, toUFix64(1.11)));
+		await shallPass(createItemListing(Alice, itemID, toUFix64(1.11)));
 	});
 
 	it("shall be able to accept a listing", async () => {
@@ -85,12 +87,12 @@ describe("NFT Storefront", () => {
 		await shallPass(mintFlow(Bob, toUFix64(100)));
 
 		// Bob shall be able to buy from Alice
-		const sellItemTransactionResult = await shallPass(sellItem(Alice, itemId, toUFix64(1.11)));
+		const createItemListingTransactionResult = await shallPass(createItemListing(Alice, itemId, toUFix64(1.11)));
 
-		const listingAvailableEvent = sellItemTransactionResult.events[0];
+		const listingAvailableEvent = createItemListingTransactionResult.events[0];
 		const listingResourceID = listingAvailableEvent.data.listingResourceID;
 
-		await shallPass(buyItem(Bob, listingResourceID, Alice));
+		await shallPass(purchaseItemListing(Bob, listingResourceID, Alice));
 
 		const itemCount = await getKittyItemCount(Bob);
 		expect(itemCount).toBe(1);
@@ -115,13 +117,13 @@ describe("NFT Storefront", () => {
 		await getKittyItem(Alice, itemId);
 
 		// Listing item for sale shall pass
-		const sellItemTransactionResult = await shallPass(sellItem(Alice, itemId, toUFix64(1.11)));
+		const createItemListingTransactionResult = await shallPass(createItemListing(Alice, itemId, toUFix64(1.11)));
 
-		const listingAvailableEvent = sellItemTransactionResult.events[0];
+		const listingAvailableEvent = createItemListingTransactionResult.events[0];
 		const listingResourceID = listingAvailableEvent.data.listingResourceID;
 
 		// Alice shall be able to remove item from sale
-		await shallPass(removeItem(Alice, listingResourceID));
+		await shallPass(removeItemListing(Alice, listingResourceID));
 
 		const listingCount = await getListingCount(Alice);
 		expect(listingCount).toBe(0);


### PR DESCRIPTION
- fix Cadence tests by importing the correct functions (which were renamed in previous commits; CI pipeline did NOT capture this because Cadence tests were disabled due to intermittent failure described in https://github.com/onflow/flow-js-testing/issues/61)
- add delays to Jest fixures to address intermittent test failures
- revive Cadence tests in Github actions
- updated README to remove outdated test contents (we no longer have Golang tests; all tests here are JS)