### PR TITLE
upgrade flow-js-testing library

### DIFF
--- a/cadence/tests/package.json
+++ b/cadence/tests/package.json
@@ -21,7 +21,7 @@
 		"@babel/preset-env": "^7.14.1",
 		"@onflow/types": "0.0.4",
 		"babel-jest": "^27.0.2",
-		"flow-js-testing": "^0.1.13",
+		"flow-js-testing": "^0.2.1",
 		"jest": "^27.0.4",
 		"prettier": "^2.3.0"
 	},

--- a/cadence/tests/src/common.js
+++ b/cadence/tests/src/common.js
@@ -1,4 +1,5 @@
 import { getAccountAddress } from "flow-js-testing";
+import { deployContractByName, executeScript, sendTransaction } from "flow-js-testing";
 
 const UFIX64_PRECISION = 8;
 
@@ -6,3 +7,27 @@ const UFIX64_PRECISION = 8;
 export const toUFix64 = (value) => value.toFixed(UFIX64_PRECISION);
 
 export const getKittyAdminAddress = async () => getAccountAddress("KittyAdmin");
+
+export const sendTransactionWithErrorRaised = async (...props) => {
+    const [resp, err] = await sendTransaction(...props);
+    if (err) {
+        throw err;
+    }
+    return resp;
+}
+
+export const executeScriptWithErrorRaised = async (...props) => {
+    const [resp, err] = await executeScript(...props);
+    if (err) {
+        throw err;
+    }
+    return resp;
+}
+
+export const deployContractByNameWithErrorRaised = async (...props) => {
+    const [resp, err] = await deployContractByName(...props);
+    if (err) {
+        throw err;
+    }
+    return resp;
+}

--- a/cadence/tests/src/kitty-items.js
+++ b/cadence/tests/src/kitty-items.js
@@ -1,5 +1,9 @@
-import { deployContractByName, executeScript, mintFlow, sendTransaction } from "flow-js-testing";
-
+import { mintFlow } from "flow-js-testing";
+import { 
+	sendTransactionWithErrorRaised, 
+	executeScriptWithErrorRaised, 
+	deployContractByNameWithErrorRaised 
+} from "./common"
 import { getKittyAdminAddress } from "./common";
 
 export const types = {
@@ -27,10 +31,10 @@ export const deployKittyItems = async () => {
 	const KittyAdmin = await getKittyAdminAddress();
 	await mintFlow(KittyAdmin, "10.0");
 
-	await deployContractByName({ to: KittyAdmin, name: "NonFungibleToken" });
+	await deployContractByNameWithErrorRaised({ to: KittyAdmin, name: "NonFungibleToken" });
 
 	const addressMap = { NonFungibleToken: KittyAdmin };
-	return deployContractByName({ to: KittyAdmin, name: "KittyItems", addressMap });
+	return deployContractByNameWithErrorRaised({ to: KittyAdmin, name: "KittyItems", addressMap });
 };
 
 /*
@@ -43,7 +47,7 @@ export const setupKittyItemsOnAccount = async (account) => {
 	const name = "kittyItems/setup_account";
 	const signers = [account];
 
-	return sendTransaction({ name, signers });
+	return sendTransactionWithErrorRaised({ name, signers });
 };
 
 /*
@@ -54,7 +58,7 @@ export const setupKittyItemsOnAccount = async (account) => {
 export const getKittyItemSupply = async () => {
 	const name = "kittyItems/get_kitty_items_supply";
 
-	return executeScript({ name });
+	return executeScriptWithErrorRaised({ name });
 };
 
 /*
@@ -71,7 +75,7 @@ export const mintKittyItem = async (recipient, itemType, itemRarity) => {
 	const args = [recipient, itemType, itemRarity];
 	const signers = [KittyAdmin];
 
-	return sendTransaction({ name, args, signers });
+	return sendTransactionWithErrorRaised({ name, args, signers });
 };
 
 /*
@@ -87,7 +91,7 @@ export const transferKittyItem = async (sender, recipient, itemId) => {
 	const args = [recipient, itemId];
 	const signers = [sender];
 
-	return sendTransaction({ name, args, signers });
+	return sendTransactionWithErrorRaised({ name, args, signers });
 };
 
 /*
@@ -101,7 +105,7 @@ export const getKittyItem = async (account, itemID) => {
 	const name = "kittyItems/get_kitty_item";
 	const args = [account, itemID];
 
-	return executeScript({ name, args });
+	return executeScriptWithErrorRaised({ name, args });
 };
 
 /*
@@ -114,5 +118,5 @@ export const getKittyItemCount = async (account) => {
 	const name = "kittyItems/get_collection_length";
 	const args = [account];
 
-	return executeScript({ name, args });
+	return executeScriptWithErrorRaised({ name, args });
 };

--- a/cadence/tests/src/nft-storefront.js
+++ b/cadence/tests/src/nft-storefront.js
@@ -1,4 +1,8 @@
-import { deployContractByName, executeScript, sendTransaction } from "flow-js-testing";
+import { 
+	sendTransactionWithErrorRaised, 
+	executeScriptWithErrorRaised, 
+	deployContractByNameWithErrorRaised 
+} from "./common"
 import { getKittyAdminAddress } from "./common";
 import { deployKittyItems, setupKittyItemsOnAccount } from "./kitty-items";
 
@@ -17,7 +21,7 @@ export const deployNFTStorefront = async () => {
 		KittyItems: KittyAdmin,
 	};
 
-	return deployContractByName({ to: KittyAdmin, name: "NFTStorefront", addressMap });
+	return deployContractByNameWithErrorRaised({ to: KittyAdmin, name: "NFTStorefront", addressMap });
 };
 
 /*
@@ -33,7 +37,7 @@ export const setupStorefrontOnAccount = async (account) => {
 	const name = "nftStorefront/setup_account";
 	const signers = [account];
 
-	return sendTransaction({ name, signers });
+	return sendTransactionWithErrorRaised({ name, signers });
 };
 
 /*
@@ -49,7 +53,7 @@ export const createItemListing = async (seller, itemId, price) => {
 	const args = [itemId, price];
 	const signers = [seller];
 
-	return sendTransaction({ name, args, signers });
+	return sendTransactionWithErrorRaised({ name, args, signers });
 };
 
 /*
@@ -65,7 +69,7 @@ export const purchaseItemListing = async (buyer, resourceId, seller) => {
 	const args = [resourceId, seller];
 	const signers = [buyer];
 
-	return sendTransaction({ name, args, signers });
+	return sendTransactionWithErrorRaised({ name, args, signers });
 };
 
 /*
@@ -80,7 +84,7 @@ export const removeItemListing = async (owner, itemId) => {
 	const signers = [owner];
 	const args = [itemId];
 
-	return sendTransaction({ name, args, signers });
+	return sendTransactionWithErrorRaised({ name, args, signers });
 };
 
 /*
@@ -93,5 +97,5 @@ export const getListingCount = async (account) => {
 	const name = "nftStorefront/get_listings_length";
 	const args = [account];
 
-	return executeScript({ name, args });
+	return executeScriptWithErrorRaised({ name, args });
 };


### PR DESCRIPTION
Starting 0.2.0, flow-js-testing library introduced a breaking change in terms of exception handling -- instead of raising the error encountered when running script/transaction, the library will return the error along with the data (Golang style). This requires code update on tests to raise the error if the error is not nil. 
This change introduced three wrappers which will perform the check and raise the error if it's present