### PR TITLE
use flow-js-testing lib 0.2.2

### DIFF
--- a/cadence/tests/package.json
+++ b/cadence/tests/package.json
@@ -21,7 +21,7 @@
 		"@babel/preset-env": "^7.14.1",
 		"@onflow/types": "0.0.4",
 		"babel-jest": "^27.0.2",
-		"flow-js-testing": "^0.2.1",
+		"flow-js-testing": "^0.2.2",
 		"jest": "^27.0.4",
 		"prettier": "^2.3.0"
 	},


### PR DESCRIPTION
Pilot usage of 0.2.2 (introduced in PR https://github.com/onflow/flow-js-testing/pull/73) of flow-js-testing library which makes request to getBlock() API to determine readiness of the Flow emulator (instead of relying on logging lines)
We can upgrade to a stable version (i.e 0.2.2) when the alpha version is vetted by the community. 