### PR TITLE
Run npm install in api Dockerfile

### DIFF
--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -1,8 +1,8 @@
 FROM node:14-alpine
 
 WORKDIR /api
-RUN npm install typescript
 COPY ./api .
 COPY ./cadence /cadence
+RUN npm i
 EXPOSE 3001
 CMD npm run dev


### PR DESCRIPTION
I was getting `tsnd: not found` errors in the api container. Adding npm i to the Dockerfile fixed it. Another similar error report: https://forum.onflow.org/t/getting-started-with-kitty-item-demo-project/2324/2

### Tests
- Successfully started the api container