### PR TITLE
Update storefront event address

### DIFF
--- a/web/src/util/events.js
+++ b/web/src/util/events.js
@@ -18,6 +18,7 @@ export const getKittyItemsEventByType = (events, type) => {
 export const getStorefrontEventByType = (events, type) => {
   return events.find(
     event =>
-      event.type === `A.${fcl.sansPrefix(publicConfig.flowAddress)}.${type}`
+      event.type ===
+      `A.${fcl.sansPrefix(publicConfig.contractNftStorefront)}.${type}`
   )
 }


### PR DESCRIPTION
#190 split the storefront address from the flow address to support testnet deploys. This updates the address used to query for events.

### Tests
- NFTStorefront.ListingAvailable was found on testnet