### PR TITLE
Fix useApiListings param argument on ProfileAccountItems

### DIFF
--- a/web/src/components/ProfileAccountItems.jsx
+++ b/web/src/components/ProfileAccountItems.jsx
@@ -6,7 +6,9 @@ import useApiListings from "src/hooks/useApiListings"
 export default function ProfileAccountItems({address}) {
   // The Storefront only returns listing IDs, so we need to fetch
   // the listing objects from the API.
-  const {listings, isLoading: isListingsLoading} = useApiListings(address)
+  const {listings, isLoading: isListingsLoading} = useApiListings({
+    owner: address,
+  })
   const {data: itemIds, isAccountItemsLoading} = useAccountItems(address)
   const isLoading =
     isListingsLoading || isAccountItemsLoading || !listings || !itemIds


### PR DESCRIPTION
useApiListings was using the wrong param format

### Tests
- Profile account items were successfully loaded on testnet