### PR TITLE
Change KittyItems to support secure cadence and implement Metadata standard

### DIFF
--- a/cadence/contracts/KittyItems.cdc
+++ b/cadence/contracts/KittyItems.cdc
@@ -163,7 +163,7 @@ pub contract KittyItems: NonFungibleToken {
     // Collection
     // A collection of KittyItem NFTs owned by an account
     //
-    pub resource Collection: KittyItemsCollectionPublic, NonFungibleToken.Provider, NonFungibleToken.Receiver, NonFungibleToken.CollectionPublic {
+    pub resource Collection: KittyItemsCollectionPublic, NonFungibleToken.Provider, NonFungibleToken.Receiver, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection {
         // dictionary of NFT conforming tokens
         // NFT is a resource type with an `UInt64` ID field
         //
@@ -224,6 +224,12 @@ pub contract KittyItems: NonFungibleToken {
             } else {
                 return nil
             }
+        }
+
+        pub fun borrowViewResolver(id: UInt64): &AnyResource{MetadataViews.Resolver} {
+            let nft = (&self.ownedNFTs[id] as auth &NonFungibleToken.NFT?)!
+            let kittyItem = nft as! &KittyItems.NFT
+            return kittyItem as &AnyResource{MetadataViews.Resolver}
         }
 
         // destructor

--- a/cadence/contracts/KittyItems.cdc
+++ b/cadence/contracts/KittyItems.cdc
@@ -209,7 +209,7 @@ pub contract KittyItems: NonFungibleToken {
         // so that the caller can read its metadata and call its methods
         //
         pub fun borrowNFT(id: UInt64): &NonFungibleToken.NFT {
-            return &self.ownedNFTs[id] as &NonFungibleToken.NFT
+            return (&self.ownedNFTs[id] as &NonFungibleToken.NFT?)!
         }
 
         // borrowKittyItem
@@ -219,7 +219,7 @@ pub contract KittyItems: NonFungibleToken {
         //
         pub fun borrowKittyItem(id: UInt64): &KittyItems.NFT? {
             if self.ownedNFTs[id] != nil {
-                let ref = &self.ownedNFTs[id] as auth &NonFungibleToken.NFT
+                let ref = (&self.ownedNFTs[id] as auth &NonFungibleToken.NFT?)!
                 return ref as! &KittyItems.NFT
             } else {
                 return nil

--- a/cadence/contracts/NFTStorefront.cdc
+++ b/cadence/contracts/NFTStorefront.cdc
@@ -439,7 +439,7 @@ pub contract NFTStorefront {
         //
         pub fun borrowListing(listingResourceID: UInt64): &Listing{ListingPublic}? {
             if self.listings[listingResourceID] != nil {
-                return &self.listings[listingResourceID] as! &Listing{ListingPublic}
+                return (&self.listings[listingResourceID] as! &Listing{ListingPublic}?)!
             } else {
                 return nil
             }

--- a/cadence/tests/package-lock.json
+++ b/cadence/tests/package-lock.json
@@ -9362,6 +9362,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/openapi-types": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.0.tgz",
+			"integrity": "sha512-GB+QO6o1hAtKsb8tP3/FTD5jpkdKrf42L4Gel9UySngMurzr+Q9pO+dtnmySQCzoCEfJr39IH6bveEn71xNcVg==",
+			"peer": true
+		},
 		"node_modules/optionator": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -19326,6 +19332,12 @@
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
+		},
+		"openapi-types": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.0.tgz",
+			"integrity": "sha512-GB+QO6o1hAtKsb8tP3/FTD5jpkdKrf42L4Gel9UySngMurzr+Q9pO+dtnmySQCzoCEfJr39IH6bveEn71xNcVg==",
+			"peer": true
 		},
 		"optionator": {
 			"version": "0.8.3",

--- a/cadence/transactions/kittyItems/setup_account.cdc
+++ b/cadence/transactions/kittyItems/setup_account.cdc
@@ -1,5 +1,6 @@
 import NonFungibleToken from "../../contracts/NonFungibleToken.cdc"
 import KittyItems from "../../contracts/KittyItems.cdc"
+import MetadataViews from "../../contracts/MetadataViews.cdc"
 
 // This transaction configures an account to hold Kitty Items.
 
@@ -15,7 +16,7 @@ transaction {
             signer.save(<-collection, to: KittyItems.CollectionStoragePath)
 
             // create a public capability for the collection
-            signer.link<&KittyItems.Collection{NonFungibleToken.CollectionPublic, KittyItems.KittyItemsCollectionPublic}>(KittyItems.CollectionPublicPath, target: KittyItems.CollectionStoragePath)
+            signer.link<&KittyItems.Collection{NonFungibleToken.CollectionPublic, KittyItems.KittyItemsCollectionPublic, MetadataViews.ResolverCollection}>(KittyItems.CollectionPublicPath, target: KittyItems.CollectionStoragePath)
         }
     }
 }


### PR DESCRIPTION
**Summary**

This repo is something is great for learning! It should implement the changes required for `Secure Cadence` and the NFT Standard so more people will implement their NFTs correctly.

I installed the Secure Cadence version of Flow and updated the contract to adhere to it. 

**Test Plan**
Ran the JS test suite and confirmed everything passes. Please let me know if I missed anything.

<img width="730" alt="Screen Shot 2022-05-17 at 9 45 21 AM" src="https://user-images.githubusercontent.com/5430668/168825694-af1ac860-b47d-4fa1-9046-3cf2685cad76.png">




> NOTE: The build doesn't use the most up to date flow version. I can change this too but left it out for now.

