### PR TITLE
Update @onflow/flow-js-testing to 0.3.0-alpha.8

### DIFF
--- a/cadence/tests/package-lock.json
+++ b/cadence/tests/package-lock.json
@@ -17,9 +17,9 @@
 			"devDependencies": {
 				"@babel/core": "^7.14.0",
 				"@babel/preset-env": "^7.14.1",
+				"@onflow/flow-js-testing": "^0.3.0-alpha.8",
 				"@onflow/types": "0.0.4",
 				"babel-jest": "^27.0.2",
-				"flow-js-testing": "^0.2.3-alpha.4",
 				"jest": "^27.0.4",
 				"prettier": "^2.3.0"
 			}
@@ -2203,6 +2203,97 @@
 			"integrity": "sha512-umvYsAwejX2yGJ5OFxM1dEaKmFEXf+34f4rJfVkfEYztgJqLkUbBkEB8HQsI8M78QUpWkWuNArqwbFvFerBbHA==",
 			"dev": true
 		},
+		"node_modules/@onflow/flow-js-testing": {
+			"version": "0.3.0-alpha.8",
+			"resolved": "https://registry.npmjs.org/@onflow/flow-js-testing/-/flow-js-testing-0.3.0-alpha.8.tgz",
+			"integrity": "sha512-8PvRJBSo1CxgJ1I87GpuOvJB/P/KquoCEdsxANByyTrGyhvvojUML/D+1R2AKr4btBfpUABAJxSlQu6HLF91iA==",
+			"dev": true,
+			"dependencies": {
+				"@onflow/config": "^0.0.2",
+				"@onflow/fcl": "^0.0.78",
+				"@onflow/fcl-config": "^0.0.1",
+				"@onflow/types": "^0.0.6",
+				"elliptic": "^6.5.4",
+				"esm": "^3.2.25",
+				"flow-cadut": "^0.1.15",
+				"jest-environment-uint8array": "^1.0.0",
+				"rimraf": "^3.0.2",
+				"rlp": "^2.2.6",
+				"sha3": "^2.1.4",
+				"yargs": "^17.0.1"
+			},
+			"bin": {
+				"flow-js-testing": "bin/index.js"
+			}
+		},
+		"node_modules/@onflow/flow-js-testing/node_modules/@onflow/fcl": {
+			"version": "0.0.78",
+			"resolved": "https://registry.npmjs.org/@onflow/fcl/-/fcl-0.0.78.tgz",
+			"integrity": "sha512-zWtzCjG2URWXLblSsXiSKr3qBroq2BSVGsZrWeosbmup/03fb/MJ10w3ECF83Cd2m/M0TevSSp+hcpdBVLZSfw==",
+			"dev": true,
+			"dependencies": {
+				"@onflow/interaction": "0.0.11",
+				"@onflow/rlp": "0.0.3",
+				"@onflow/sdk": "0.0.56",
+				"@onflow/types": "0.0.6",
+				"@onflow/util-actor": "0.0.2",
+				"@onflow/util-address": "0.0.0",
+				"@onflow/util-invariant": "0.0.0",
+				"@onflow/util-template": "0.0.1",
+				"@onflow/util-uid": "0.0.1"
+			}
+		},
+		"node_modules/@onflow/flow-js-testing/node_modules/@onflow/sdk": {
+			"version": "0.0.56",
+			"resolved": "https://registry.npmjs.org/@onflow/sdk/-/sdk-0.0.56.tgz",
+			"integrity": "sha512-yYOE+5Tvgprqo01vSxIgYTu4fO6sDFfyueVYFgzXx/F0fdHqy0zfAq+gEVjtWG+LvVD/YvR8eRbcBpfvXu1USA==",
+			"dev": true,
+			"dependencies": {
+				"@improbable-eng/grpc-web": "^0.14.0",
+				"@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
+				"@onflow/protobuf": "^0.1.8",
+				"@onflow/rlp": "^0.0.3",
+				"@onflow/util-actor": "0.0.2",
+				"@onflow/util-address": "^0.0.0",
+				"@onflow/util-invariant": "^0.0.0",
+				"@onflow/util-template": "0.0.1",
+				"deepmerge": "^4.2.2",
+				"sha3": "^2.1.4"
+			}
+		},
+		"node_modules/@onflow/flow-js-testing/node_modules/@onflow/types": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@onflow/types/-/types-0.0.6.tgz",
+			"integrity": "sha512-2eBrmqiFO37EUOJvzksygP8Wu6lL/m9az36AF0qYdGQW/79KGCHBCchUsIzxyGt8UDXl/dgnIcMkiTH7tWZqXg==",
+			"dev": true
+		},
+		"node_modules/@onflow/flow-js-testing/node_modules/yargs": {
+			"version": "17.5.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+			"integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@onflow/flow-js-testing/node_modules/yargs-parser": {
+			"version": "21.0.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+			"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@onflow/interaction": {
 			"version": "0.0.11",
 			"resolved": "https://registry.npmjs.org/@onflow/interaction/-/interaction-0.0.11.tgz",
@@ -2581,7 +2672,7 @@
 		"node_modules/anymatch/node_modules/normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
 			"dev": true,
 			"dependencies": {
 				"remove-trailing-separator": "^1.0.1"
@@ -2654,7 +2745,7 @@
 		"node_modules/arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -2672,7 +2763,7 @@
 		"node_modules/arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -2689,7 +2780,7 @@
 		"node_modules/array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -2713,19 +2804,38 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/array.prototype.reduce": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.4.tgz",
+			"integrity": "sha512-WnM+AjG/DvLRLo4DDl+r+SvCzYtD2Jd9oeBYMcEaI7t3fFrHY9M53/wdLcTvmZNQ70IU6Htj0emFkZ5TS+lrdw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.2",
+				"es-array-method-boxes-properly": "^1.0.0",
+				"is-string": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/async": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-			"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
 			"dev": true
 		},
 		"node_modules/asynckit": {
@@ -2981,7 +3091,7 @@
 		"node_modules/base/node_modules/define-property": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-			"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+			"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
 			"dev": true,
 			"dependencies": {
 				"is-descriptor": "^1.0.0"
@@ -3100,7 +3210,7 @@
 		"node_modules/braces/node_modules/extend-shallow": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 			"dev": true,
 			"dependencies": {
 				"is-extendable": "^0.1.0"
@@ -3112,7 +3222,7 @@
 		"node_modules/braces/node_modules/is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -3121,7 +3231,7 @@
 		"node_modules/brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
 			"dev": true
 		},
 		"node_modules/browser-headers": {
@@ -3344,7 +3454,7 @@
 		"node_modules/class-utils/node_modules/define-property": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-			"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
 			"dev": true,
 			"dependencies": {
 				"is-descriptor": "^0.1.0"
@@ -3356,7 +3466,7 @@
 		"node_modules/class-utils/node_modules/is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -3368,7 +3478,7 @@
 		"node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -3380,7 +3490,7 @@
 		"node_modules/class-utils/node_modules/is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -3392,7 +3502,7 @@
 		"node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -3491,7 +3601,7 @@
 		"node_modules/collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
 			"dev": true,
 			"dependencies": {
 				"map-visit": "^1.0.0",
@@ -3604,7 +3714,7 @@
 		"node_modules/copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -3726,7 +3836,7 @@
 		"node_modules/decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -3741,7 +3851,7 @@
 		"node_modules/decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10"
@@ -3776,14 +3886,18 @@
 			}
 		},
 		"node_modules/define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"dependencies": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/define-property": {
@@ -3906,7 +4020,7 @@
 		"node_modules/emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.10"
@@ -3931,30 +4045,33 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+			"integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"function.prototype.name": "^1.1.5",
 				"get-intrinsic": "^1.1.1",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.2",
+				"has-property-descriptors": "^1.0.0",
+				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
 				"is-callable": "^1.2.4",
-				"is-negative-zero": "^2.0.1",
+				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.1",
+				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
-				"is-weakref": "^1.0.1",
-				"object-inspect": "^1.11.0",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.12.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
-				"string.prototype.trimend": "^1.0.4",
-				"string.prototype.trimstart": "^1.0.4",
-				"unbox-primitive": "^1.0.1"
+				"regexp.prototype.flags": "^1.4.3",
+				"string.prototype.trimend": "^1.0.5",
+				"string.prototype.trimstart": "^1.0.5",
+				"unbox-primitive": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -4213,7 +4330,7 @@
 		"node_modules/expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^2.3.3",
@@ -4240,7 +4357,7 @@
 		"node_modules/expand-brackets/node_modules/define-property": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-			"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
 			"dev": true,
 			"dependencies": {
 				"is-descriptor": "^0.1.0"
@@ -4252,7 +4369,7 @@
 		"node_modules/expand-brackets/node_modules/extend-shallow": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 			"dev": true,
 			"dependencies": {
 				"is-extendable": "^0.1.0"
@@ -4264,7 +4381,7 @@
 		"node_modules/expand-brackets/node_modules/is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -4276,7 +4393,7 @@
 		"node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -4288,7 +4405,7 @@
 		"node_modules/expand-brackets/node_modules/is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -4300,7 +4417,7 @@
 		"node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -4326,7 +4443,7 @@
 		"node_modules/expand-brackets/node_modules/is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -4344,7 +4461,7 @@
 		"node_modules/expand-brackets/node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true
 		},
 		"node_modules/expect": {
@@ -4392,7 +4509,7 @@
 		"node_modules/extend-shallow": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
 			"dev": true,
 			"dependencies": {
 				"assign-symbols": "^1.0.0",
@@ -4437,7 +4554,7 @@
 		"node_modules/extglob/node_modules/define-property": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-			"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+			"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
 			"dev": true,
 			"dependencies": {
 				"is-descriptor": "^1.0.0"
@@ -4449,7 +4566,7 @@
 		"node_modules/extglob/node_modules/extend-shallow": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 			"dev": true,
 			"dependencies": {
 				"is-extendable": "^0.1.0"
@@ -4461,7 +4578,7 @@
 		"node_modules/extglob/node_modules/is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -4557,7 +4674,7 @@
 		"node_modules/fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
 			"dev": true,
 			"dependencies": {
 				"extend-shallow": "^2.0.1",
@@ -4572,7 +4689,7 @@
 		"node_modules/fill-range/node_modules/extend-shallow": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 			"dev": true,
 			"dependencies": {
 				"is-extendable": "^0.1.0"
@@ -4584,7 +4701,7 @@
 		"node_modules/fill-range/node_modules/is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -4619,24 +4736,62 @@
 			}
 		},
 		"node_modules/flow-cadut": {
-			"version": "0.1.15-alpha.12",
-			"resolved": "https://registry.npmjs.org/flow-cadut/-/flow-cadut-0.1.15-alpha.12.tgz",
-			"integrity": "sha512-EBEC3N+G7bhW6c0b5WGfJE3ewQf5qCqLqyim7X36UuK2S9ybkMHFyfrQqDKTtPyhQpq4/lmi5ax/GG5ou843kA==",
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/flow-cadut/-/flow-cadut-0.1.15.tgz",
+			"integrity": "sha512-77lFJvhTGckWtnX/BV25qfe0/wsFbmeBRrRGycWa0uzZeVJV1RSk4VmtGkwHfO32Ndi7Du+87SCV92JUegV/ig==",
 			"dev": true,
 			"dependencies": {
 				"@onflow/config": "0.0.2",
-				"@onflow/fcl": "^0.0.77",
+				"@onflow/fcl": "^0.0.78",
 				"@onflow/types": "^0.0.6",
+				"elliptic": "^6.5.4",
 				"esm": "^3.2.25",
 				"handlebars": "^4.7.7",
 				"handlebars-loader": "^1.7.1",
 				"prettier": "^2.3.0",
 				"rimraf": "^3.0.2",
+				"rlp": "^3.0.0",
+				"sha3": "^2.1.4",
 				"simple-git": "^2.40.0",
 				"yargs": "^15.4.1"
 			},
 			"bin": {
 				"flow-generate": "bin/generate.js"
+			}
+		},
+		"node_modules/flow-cadut/node_modules/@onflow/fcl": {
+			"version": "0.0.78",
+			"resolved": "https://registry.npmjs.org/@onflow/fcl/-/fcl-0.0.78.tgz",
+			"integrity": "sha512-zWtzCjG2URWXLblSsXiSKr3qBroq2BSVGsZrWeosbmup/03fb/MJ10w3ECF83Cd2m/M0TevSSp+hcpdBVLZSfw==",
+			"dev": true,
+			"dependencies": {
+				"@onflow/interaction": "0.0.11",
+				"@onflow/rlp": "0.0.3",
+				"@onflow/sdk": "0.0.56",
+				"@onflow/types": "0.0.6",
+				"@onflow/util-actor": "0.0.2",
+				"@onflow/util-address": "0.0.0",
+				"@onflow/util-invariant": "0.0.0",
+				"@onflow/util-template": "0.0.1",
+				"@onflow/util-uid": "0.0.1"
+			}
+		},
+		"node_modules/flow-cadut/node_modules/@onflow/sdk": {
+			"version": "0.0.56",
+			"resolved": "https://registry.npmjs.org/@onflow/sdk/-/sdk-0.0.56.tgz",
+			"integrity": "sha512-yYOE+5Tvgprqo01vSxIgYTu4fO6sDFfyueVYFgzXx/F0fdHqy0zfAq+gEVjtWG+LvVD/YvR8eRbcBpfvXu1USA==",
+			"dev": true,
+			"dependencies": {
+				"@improbable-eng/grpc-web": "^0.14.0",
+				"@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
+				"@onflow/protobuf": "^0.1.8",
+				"@onflow/rlp": "^0.0.3",
+				"@onflow/util-actor": "0.0.2",
+				"@onflow/util-address": "^0.0.0",
+				"@onflow/util-invariant": "^0.0.0",
+				"@onflow/util-template": "0.0.1",
+				"deepmerge": "^4.2.2",
+				"sha3": "^2.1.4"
 			}
 		},
 		"node_modules/flow-cadut/node_modules/@onflow/types": {
@@ -4688,6 +4843,15 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
+		},
+		"node_modules/flow-cadut/node_modules/rlp": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-3.0.0.tgz",
+			"integrity": "sha512-PD6U2PGk6Vq2spfgiWZdomLvRGDreBLxi5jv5M8EpRo3pU6VEm31KO+HFxE18Q3vgqfDrQ9pZA3FP95rkijNKw==",
+			"dev": true,
+			"bin": {
+				"rlp": "bin/rlp"
+			}
 		},
 		"node_modules/flow-cadut/node_modules/wrap-ansi": {
 			"version": "6.2.0",
@@ -4744,97 +4908,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/flow-js-testing": {
-			"version": "0.2.3-alpha.4",
-			"resolved": "https://registry.npmjs.org/flow-js-testing/-/flow-js-testing-0.2.3-alpha.4.tgz",
-			"integrity": "sha512-dQQYlQnaCdZH6HUZGVp+zTUHAw57SZJB6hy0miBSTqAjxf2/+dE22n4EnMddSm8M7hsgcD/My1ugjvYzMk+GDw==",
-			"dev": true,
-			"dependencies": {
-				"@onflow/config": "^0.0.2",
-				"@onflow/fcl": "^0.0.78",
-				"@onflow/fcl-config": "^0.0.1",
-				"@onflow/types": "^0.0.6",
-				"elliptic": "^6.5.4",
-				"esm": "^3.2.25",
-				"flow-cadut": "^0.1.15-alpha.12",
-				"jest-environment-uint8array": "^1.0.0",
-				"rimraf": "^3.0.2",
-				"rlp": "^2.2.6",
-				"sha3": "^2.1.4",
-				"yargs": "^17.0.1"
-			},
-			"bin": {
-				"flow-js-testing": "bin/index.js"
-			}
-		},
-		"node_modules/flow-js-testing/node_modules/@onflow/fcl": {
-			"version": "0.0.78",
-			"resolved": "https://registry.npmjs.org/@onflow/fcl/-/fcl-0.0.78.tgz",
-			"integrity": "sha512-zWtzCjG2URWXLblSsXiSKr3qBroq2BSVGsZrWeosbmup/03fb/MJ10w3ECF83Cd2m/M0TevSSp+hcpdBVLZSfw==",
-			"dev": true,
-			"dependencies": {
-				"@onflow/interaction": "0.0.11",
-				"@onflow/rlp": "0.0.3",
-				"@onflow/sdk": "0.0.56",
-				"@onflow/types": "0.0.6",
-				"@onflow/util-actor": "0.0.2",
-				"@onflow/util-address": "0.0.0",
-				"@onflow/util-invariant": "0.0.0",
-				"@onflow/util-template": "0.0.1",
-				"@onflow/util-uid": "0.0.1"
-			}
-		},
-		"node_modules/flow-js-testing/node_modules/@onflow/sdk": {
-			"version": "0.0.56",
-			"resolved": "https://registry.npmjs.org/@onflow/sdk/-/sdk-0.0.56.tgz",
-			"integrity": "sha512-yYOE+5Tvgprqo01vSxIgYTu4fO6sDFfyueVYFgzXx/F0fdHqy0zfAq+gEVjtWG+LvVD/YvR8eRbcBpfvXu1USA==",
-			"dev": true,
-			"dependencies": {
-				"@improbable-eng/grpc-web": "^0.14.0",
-				"@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
-				"@onflow/protobuf": "^0.1.8",
-				"@onflow/rlp": "^0.0.3",
-				"@onflow/util-actor": "0.0.2",
-				"@onflow/util-address": "^0.0.0",
-				"@onflow/util-invariant": "^0.0.0",
-				"@onflow/util-template": "0.0.1",
-				"deepmerge": "^4.2.2",
-				"sha3": "^2.1.4"
-			}
-		},
-		"node_modules/flow-js-testing/node_modules/@onflow/types": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/@onflow/types/-/types-0.0.6.tgz",
-			"integrity": "sha512-2eBrmqiFO37EUOJvzksygP8Wu6lL/m9az36AF0qYdGQW/79KGCHBCchUsIzxyGt8UDXl/dgnIcMkiTH7tWZqXg==",
-			"dev": true
-		},
-		"node_modules/flow-js-testing/node_modules/yargs": {
-			"version": "17.3.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-			"integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/flow-js-testing/node_modules/yargs-parser": {
-			"version": "21.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-			"integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/for-each": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -4847,7 +4920,7 @@
 		"node_modules/for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -4870,7 +4943,7 @@
 		"node_modules/fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
 			"dev": true,
 			"dependencies": {
 				"map-cache": "^0.2.2"
@@ -4902,6 +4975,23 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"node_modules/function.prototype.name": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0",
+				"functions-have-names": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/functions-have-names": {
 			"version": "1.2.2",
@@ -4979,7 +5069,7 @@
 		"node_modules/get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -5090,12 +5180,12 @@
 			}
 		},
 		"node_modules/handlebars-loader": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/handlebars-loader/-/handlebars-loader-1.7.1.tgz",
-			"integrity": "sha512-Q+Z/hDPQzU8ZTlVnAe/0T1LHABlyhL7opNcSKcQDhmUXK2ByGTqib1Z2Tfv4Ic50WqDcLFWQcOb3mhjcBRbscQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/handlebars-loader/-/handlebars-loader-1.7.2.tgz",
+			"integrity": "sha512-rEzru8REzqeJlbotJD+gPQ8AHyxcAjeXbGqGmrz3+sbjecI0ungieONwMR27Htr+AoKI5W36oPLwcwGrPzO8gw==",
 			"dev": true,
 			"dependencies": {
-				"async": "~0.2.10",
+				"async": "^3.2.2",
 				"fastparse": "^1.0.0",
 				"loader-utils": "1.0.x",
 				"object-assign": "^4.1.0"
@@ -5125,9 +5215,9 @@
 			}
 		},
 		"node_modules/has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -5141,10 +5231,21 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dependencies": {
+				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -5169,7 +5270,7 @@
 		"node_modules/has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
 			"dev": true,
 			"dependencies": {
 				"get-value": "^2.0.6",
@@ -5183,7 +5284,7 @@
 		"node_modules/has-values": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
 			"dev": true,
 			"dependencies": {
 				"is-number": "^3.0.0",
@@ -5196,7 +5297,7 @@
 		"node_modules/has-values/node_modules/kind-of": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-			"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+			"integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -5218,7 +5319,7 @@
 		"node_modules/hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
 			"dev": true,
 			"dependencies": {
 				"hash.js": "^1.0.3",
@@ -5522,7 +5623,7 @@
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true
 		},
 		"node_modules/is-bigint": {
@@ -5697,9 +5798,9 @@
 			}
 		},
 		"node_modules/is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -5710,7 +5811,7 @@
 		"node_modules/is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -5720,9 +5821,9 @@
 			}
 		},
 		"node_modules/is-number-object": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-			"integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
 			"dependencies": {
 				"has-tostringtag": "^1.0.0"
 			},
@@ -5736,7 +5837,7 @@
 		"node_modules/is-number/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -5792,9 +5893,12 @@
 			}
 		},
 		"node_modules/is-shared-array-buffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -5854,11 +5958,11 @@
 			}
 		},
 		"node_modules/is-weakref": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
 			"dependencies": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -5876,7 +5980,7 @@
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true
 		},
 		"node_modules/isexe": {
@@ -5888,7 +5992,7 @@
 		"node_modules/isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -7004,7 +7108,7 @@
 		"node_modules/jest-environment-uint8array/node_modules/path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -8421,7 +8525,7 @@
 		"node_modules/load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
@@ -8436,7 +8540,7 @@
 		"node_modules/load-json-file/node_modules/strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -8445,7 +8549,7 @@
 		"node_modules/loader-utils": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.4.tgz",
-			"integrity": "sha1-E/Vhl/FSOjBYkSSLTHJEVAhIQmw=",
+			"integrity": "sha512-TMS4PQ0+m0xyRGBunvDQIdhWJY6JOYeEPpHZEW0EmDhqKrQUj04xiMT3jsdVS17pUg0JzX1mJI3QiV8lXjoEng==",
 			"dev": true,
 			"dependencies": {
 				"big.js": "^3.1.3",
@@ -8459,7 +8563,7 @@
 		"node_modules/loader-utils/node_modules/json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
 			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
@@ -8639,7 +8743,7 @@
 		"node_modules/map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -8648,7 +8752,7 @@
 		"node_modules/map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
 			"dev": true,
 			"dependencies": {
 				"object-visit": "^1.0.0"
@@ -8786,7 +8890,7 @@
 		"node_modules/minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
 			"dev": true
 		},
 		"node_modules/minimatch": {
@@ -8801,9 +8905,9 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
 		},
 		"node_modules/mixin-deep": {
 			"version": "1.3.2",
@@ -8819,12 +8923,12 @@
 			}
 		},
 		"node_modules/mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
 			"dev": true,
 			"dependencies": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
@@ -8853,9 +8957,9 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
 		},
 		"node_modules/nan": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-			"integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+			"integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
 			"dev": true,
 			"optional": true
 		},
@@ -9175,7 +9279,7 @@
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -9184,7 +9288,7 @@
 		"node_modules/object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
 			"dev": true,
 			"dependencies": {
 				"copy-descriptor": "^0.1.0",
@@ -9198,7 +9302,7 @@
 		"node_modules/object-copy/node_modules/define-property": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-			"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
 			"dev": true,
 			"dependencies": {
 				"is-descriptor": "^0.1.0"
@@ -9210,7 +9314,7 @@
 		"node_modules/object-copy/node_modules/is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -9222,7 +9326,7 @@
 		"node_modules/object-copy/node_modules/is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -9257,7 +9361,7 @@
 		"node_modules/object-copy/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -9267,9 +9371,9 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -9285,7 +9389,7 @@
 		"node_modules/object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
 			"dev": true,
 			"dependencies": {
 				"isobject": "^3.0.0"
@@ -9312,14 +9416,15 @@
 			}
 		},
 		"node_modules/object.getownpropertydescriptors": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz",
-			"integrity": "sha512-VdDoCwvJI4QdC6ndjpqFmoL3/+HxffFBbcJzKi5hwLLqqx3mdbedRpfZDdK0SrOSauj8X4GzBvnDZl4vTN7dOw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.4.tgz",
+			"integrity": "sha512-sccv3L/pMModT6dJAYF3fzGMVcb38ysQ0tEE6ixv2yXJDtEIPph268OlAdJj5/qZMZDq2g/jqvwppt36uS/uQQ==",
 			"dev": true,
 			"dependencies": {
+				"array.prototype.reduce": "^1.0.4",
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.1"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.1"
 			},
 			"engines": {
 				"node": ">= 0.8"
@@ -9331,7 +9436,7 @@
 		"node_modules/object.pick": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
 			"dev": true,
 			"dependencies": {
 				"isobject": "^3.0.1"
@@ -9494,7 +9599,7 @@
 		"node_modules/p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -9547,7 +9652,7 @@
 		"node_modules/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
 			"dev": true,
 			"dependencies": {
 				"error-ex": "^1.3.1",
@@ -9566,7 +9671,7 @@
 		"node_modules/pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -9639,7 +9744,7 @@
 		"node_modules/pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -9671,7 +9776,7 @@
 		"node_modules/posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -9827,7 +9932,7 @@
 		"node_modules/read-pkg": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
 			"dev": true,
 			"dependencies": {
 				"load-json-file": "^4.0.0",
@@ -9891,7 +9996,7 @@
 		"node_modules/read-pkg-up/node_modules/path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -9984,6 +10089,22 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/regexp.prototype.flags": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+			"integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"functions-have-names": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/regexpu-core": {
 			"version": "4.7.1",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
@@ -10039,7 +10160,7 @@
 		"node_modules/remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
 			"dev": true
 		},
 		"node_modules/repeat-element": {
@@ -10054,7 +10175,7 @@
 		"node_modules/repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10"
@@ -10111,7 +10232,7 @@
 		"node_modules/resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
 			"deprecated": "https://github.com/lydell/resolve-url#deprecated",
 			"dev": true
 		},
@@ -10173,9 +10294,9 @@
 			}
 		},
 		"node_modules/rlp/node_modules/bn.js": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
 			"dev": true
 		},
 		"node_modules/rsvp": {
@@ -10253,7 +10374,7 @@
 		"node_modules/safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
 			"dev": true,
 			"dependencies": {
 				"ret": "~0.1.10"
@@ -10337,7 +10458,7 @@
 		"node_modules/sane/node_modules/is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -10370,7 +10491,7 @@
 		"node_modules/sane/node_modules/npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
 			"dev": true,
 			"dependencies": {
 				"path-key": "^2.0.0"
@@ -10382,7 +10503,7 @@
 		"node_modules/sane/node_modules/path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -10400,7 +10521,7 @@
 		"node_modules/sane/node_modules/shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
 			"dev": true,
 			"dependencies": {
 				"shebang-regex": "^1.0.0"
@@ -10412,7 +10533,7 @@
 		"node_modules/sane/node_modules/shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -10453,7 +10574,7 @@
 		"node_modules/set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
 			"dev": true
 		},
 		"node_modules/set-value": {
@@ -10474,7 +10595,7 @@
 		"node_modules/set-value/node_modules/extend-shallow": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 			"dev": true,
 			"dependencies": {
 				"is-extendable": "^0.1.0"
@@ -10486,7 +10607,7 @@
 		"node_modules/set-value/node_modules/is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -10653,7 +10774,7 @@
 		"node_modules/snapdragon-node/node_modules/define-property": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-			"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+			"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
 			"dev": true,
 			"dependencies": {
 				"is-descriptor": "^1.0.0"
@@ -10677,7 +10798,7 @@
 		"node_modules/snapdragon-util/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -10698,7 +10819,7 @@
 		"node_modules/snapdragon/node_modules/define-property": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-			"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
 			"dev": true,
 			"dependencies": {
 				"is-descriptor": "^0.1.0"
@@ -10710,7 +10831,7 @@
 		"node_modules/snapdragon/node_modules/extend-shallow": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 			"dev": true,
 			"dependencies": {
 				"is-extendable": "^0.1.0"
@@ -10722,7 +10843,7 @@
 		"node_modules/snapdragon/node_modules/is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -10734,7 +10855,7 @@
 		"node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -10746,7 +10867,7 @@
 		"node_modules/snapdragon/node_modules/is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -10758,7 +10879,7 @@
 		"node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -10784,7 +10905,7 @@
 		"node_modules/snapdragon/node_modules/is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -10802,7 +10923,7 @@
 		"node_modules/snapdragon/node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true
 		},
 		"node_modules/source-map": {
@@ -10936,7 +11057,7 @@
 		"node_modules/static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
 			"dev": true,
 			"dependencies": {
 				"define-property": "^0.2.5",
@@ -10949,7 +11070,7 @@
 		"node_modules/static-extend/node_modules/define-property": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-			"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
 			"dev": true,
 			"dependencies": {
 				"is-descriptor": "^0.1.0"
@@ -10961,7 +11082,7 @@
 		"node_modules/static-extend/node_modules/is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -10973,7 +11094,7 @@
 		"node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -10985,7 +11106,7 @@
 		"node_modules/static-extend/node_modules/is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -10997,7 +11118,7 @@
 		"node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -11083,24 +11204,26 @@
 			}
 		},
 		"node_modules/string.prototype.trimend": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+			"integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+			"integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -11129,7 +11252,7 @@
 		"node_modules/strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -11360,7 +11483,7 @@
 		"node_modules/to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
 			"dev": true,
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -11372,7 +11495,7 @@
 		"node_modules/to-object-path/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 			"dev": true,
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -11399,7 +11522,7 @@
 		"node_modules/to-regex-range": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
 			"dev": true,
 			"dependencies": {
 				"is-number": "^3.0.0",
@@ -11487,9 +11610,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-			"integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
+			"integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -11500,13 +11623,13 @@
 			}
 		},
 		"node_modules/unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			},
 			"funding": {
@@ -11571,7 +11694,7 @@
 		"node_modules/union-value/node_modules/is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -11589,7 +11712,7 @@
 		"node_modules/unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
 			"dev": true,
 			"dependencies": {
 				"has-value": "^0.3.1",
@@ -11602,7 +11725,7 @@
 		"node_modules/unset-value/node_modules/has-value": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-			"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+			"integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
 			"dev": true,
 			"dependencies": {
 				"get-value": "^2.0.3",
@@ -11616,7 +11739,7 @@
 		"node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
 			"dev": true,
 			"dependencies": {
 				"isarray": "1.0.0"
@@ -11628,7 +11751,7 @@
 		"node_modules/unset-value/node_modules/has-values": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-			"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+			"integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -11637,7 +11760,7 @@
 		"node_modules/urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
 			"deprecated": "Please see https://github.com/lydell/urix#deprecated",
 			"dev": true
 		},
@@ -11866,7 +11989,7 @@
 		"node_modules/which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
 			"dev": true
 		},
 		"node_modules/word-wrap": {
@@ -11881,7 +12004,7 @@
 		"node_modules/wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
 			"dev": true
 		},
 		"node_modules/wrap-ansi": {
@@ -13776,6 +13899,90 @@
 			"integrity": "sha512-umvYsAwejX2yGJ5OFxM1dEaKmFEXf+34f4rJfVkfEYztgJqLkUbBkEB8HQsI8M78QUpWkWuNArqwbFvFerBbHA==",
 			"dev": true
 		},
+		"@onflow/flow-js-testing": {
+			"version": "0.3.0-alpha.8",
+			"resolved": "https://registry.npmjs.org/@onflow/flow-js-testing/-/flow-js-testing-0.3.0-alpha.8.tgz",
+			"integrity": "sha512-8PvRJBSo1CxgJ1I87GpuOvJB/P/KquoCEdsxANByyTrGyhvvojUML/D+1R2AKr4btBfpUABAJxSlQu6HLF91iA==",
+			"dev": true,
+			"requires": {
+				"@onflow/config": "^0.0.2",
+				"@onflow/fcl": "^0.0.78",
+				"@onflow/fcl-config": "^0.0.1",
+				"@onflow/types": "^0.0.6",
+				"elliptic": "^6.5.4",
+				"esm": "^3.2.25",
+				"flow-cadut": "^0.1.15",
+				"jest-environment-uint8array": "^1.0.0",
+				"rimraf": "^3.0.2",
+				"rlp": "^2.2.6",
+				"sha3": "^2.1.4",
+				"yargs": "^17.0.1"
+			},
+			"dependencies": {
+				"@onflow/fcl": {
+					"version": "0.0.78",
+					"resolved": "https://registry.npmjs.org/@onflow/fcl/-/fcl-0.0.78.tgz",
+					"integrity": "sha512-zWtzCjG2URWXLblSsXiSKr3qBroq2BSVGsZrWeosbmup/03fb/MJ10w3ECF83Cd2m/M0TevSSp+hcpdBVLZSfw==",
+					"dev": true,
+					"requires": {
+						"@onflow/interaction": "0.0.11",
+						"@onflow/rlp": "0.0.3",
+						"@onflow/sdk": "0.0.56",
+						"@onflow/types": "0.0.6",
+						"@onflow/util-actor": "0.0.2",
+						"@onflow/util-address": "0.0.0",
+						"@onflow/util-invariant": "0.0.0",
+						"@onflow/util-template": "0.0.1",
+						"@onflow/util-uid": "0.0.1"
+					}
+				},
+				"@onflow/sdk": {
+					"version": "0.0.56",
+					"resolved": "https://registry.npmjs.org/@onflow/sdk/-/sdk-0.0.56.tgz",
+					"integrity": "sha512-yYOE+5Tvgprqo01vSxIgYTu4fO6sDFfyueVYFgzXx/F0fdHqy0zfAq+gEVjtWG+LvVD/YvR8eRbcBpfvXu1USA==",
+					"dev": true,
+					"requires": {
+						"@improbable-eng/grpc-web": "^0.14.0",
+						"@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
+						"@onflow/protobuf": "^0.1.8",
+						"@onflow/rlp": "^0.0.3",
+						"@onflow/util-actor": "0.0.2",
+						"@onflow/util-address": "^0.0.0",
+						"@onflow/util-invariant": "^0.0.0",
+						"@onflow/util-template": "0.0.1",
+						"deepmerge": "^4.2.2",
+						"sha3": "^2.1.4"
+					}
+				},
+				"@onflow/types": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/@onflow/types/-/types-0.0.6.tgz",
+					"integrity": "sha512-2eBrmqiFO37EUOJvzksygP8Wu6lL/m9az36AF0qYdGQW/79KGCHBCchUsIzxyGt8UDXl/dgnIcMkiTH7tWZqXg==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "17.5.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+					"integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+					"dev": true,
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.3",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^21.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "21.0.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+					"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+					"dev": true
+				}
+			}
+		},
 		"@onflow/interaction": {
 			"version": "0.0.11",
 			"resolved": "https://registry.npmjs.org/@onflow/interaction/-/interaction-0.0.11.tgz",
@@ -14111,7 +14318,7 @@
 				"normalize-path": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
 					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "^1.0.1"
@@ -14176,7 +14383,7 @@
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
 			"dev": true
 		},
 		"arr-flatten": {
@@ -14188,7 +14395,7 @@
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
 			"dev": true
 		},
 		"array-union": {
@@ -14199,7 +14406,7 @@
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
 			"dev": true
 		},
 		"array.prototype.map": {
@@ -14214,16 +14421,29 @@
 				"is-string": "^1.0.7"
 			}
 		},
+		"array.prototype.reduce": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.4.tgz",
+			"integrity": "sha512-WnM+AjG/DvLRLo4DDl+r+SvCzYtD2Jd9oeBYMcEaI7t3fFrHY9M53/wdLcTvmZNQ70IU6Htj0emFkZ5TS+lrdw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.2",
+				"es-array-method-boxes-properly": "^1.0.0",
+				"is-string": "^1.0.7"
+			}
+		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
 			"dev": true
 		},
 		"async": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-			"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
 			"dev": true
 		},
 		"asynckit": {
@@ -14421,7 +14641,7 @@
 				"define-property": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
 					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
@@ -14507,7 +14727,7 @@
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
@@ -14516,7 +14736,7 @@
 				"is-extendable": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+					"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 					"dev": true
 				}
 			}
@@ -14524,7 +14744,7 @@
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
 			"dev": true
 		},
 		"browser-headers": {
@@ -14692,7 +14912,7 @@
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
 					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
@@ -14701,7 +14921,7 @@
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -14710,7 +14930,7 @@
 						"kind-of": {
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
@@ -14721,7 +14941,7 @@
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -14730,7 +14950,7 @@
 						"kind-of": {
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
@@ -14805,7 +15025,7 @@
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
 			"dev": true,
 			"requires": {
 				"map-visit": "^1.0.0",
@@ -14909,7 +15129,7 @@
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
 			"dev": true
 		},
 		"core-js-compat": {
@@ -15005,7 +15225,7 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
 			"dev": true
 		},
 		"decimal.js": {
@@ -15017,7 +15237,7 @@
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
 			"dev": true
 		},
 		"dedent": {
@@ -15046,11 +15266,12 @@
 			}
 		},
 		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"requires": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			}
 		},
 		"define-property": {
@@ -15147,7 +15368,7 @@
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
 			"dev": true
 		},
 		"end-of-stream": {
@@ -15169,30 +15390,33 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+			"integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
 			"requires": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"function.prototype.name": "^1.1.5",
 				"get-intrinsic": "^1.1.1",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.2",
+				"has-property-descriptors": "^1.0.0",
+				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
 				"is-callable": "^1.2.4",
-				"is-negative-zero": "^2.0.1",
+				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.1",
+				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
-				"is-weakref": "^1.0.1",
-				"object-inspect": "^1.11.0",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.12.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
-				"string.prototype.trimend": "^1.0.4",
-				"string.prototype.trimstart": "^1.0.4",
-				"unbox-primitive": "^1.0.1"
+				"regexp.prototype.flags": "^1.4.3",
+				"string.prototype.trimend": "^1.0.5",
+				"string.prototype.trimstart": "^1.0.5",
+				"unbox-primitive": "^1.0.2"
 			}
 		},
 		"es-aggregate-error": {
@@ -15393,7 +15617,7 @@
 		"expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
 			"dev": true,
 			"requires": {
 				"debug": "^2.3.3",
@@ -15417,7 +15641,7 @@
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
 					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
@@ -15426,7 +15650,7 @@
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
@@ -15435,7 +15659,7 @@
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -15444,7 +15668,7 @@
 						"kind-of": {
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
@@ -15455,7 +15679,7 @@
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -15464,7 +15688,7 @@
 						"kind-of": {
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
@@ -15486,7 +15710,7 @@
 				"is-extendable": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+					"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 					"dev": true
 				},
 				"kind-of": {
@@ -15498,7 +15722,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 					"dev": true
 				}
 			}
@@ -15543,7 +15767,7 @@
 		"extend-shallow": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
 			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
@@ -15579,7 +15803,7 @@
 				"define-property": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
 					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
@@ -15588,7 +15812,7 @@
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
@@ -15597,7 +15821,7 @@
 				"is-extendable": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+					"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 					"dev": true
 				}
 			}
@@ -15680,7 +15904,7 @@
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -15692,7 +15916,7 @@
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
@@ -15701,7 +15925,7 @@
 				"is-extendable": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+					"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 					"dev": true
 				}
 			}
@@ -15726,23 +15950,61 @@
 			}
 		},
 		"flow-cadut": {
-			"version": "0.1.15-alpha.12",
-			"resolved": "https://registry.npmjs.org/flow-cadut/-/flow-cadut-0.1.15-alpha.12.tgz",
-			"integrity": "sha512-EBEC3N+G7bhW6c0b5WGfJE3ewQf5qCqLqyim7X36UuK2S9ybkMHFyfrQqDKTtPyhQpq4/lmi5ax/GG5ou843kA==",
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/flow-cadut/-/flow-cadut-0.1.15.tgz",
+			"integrity": "sha512-77lFJvhTGckWtnX/BV25qfe0/wsFbmeBRrRGycWa0uzZeVJV1RSk4VmtGkwHfO32Ndi7Du+87SCV92JUegV/ig==",
 			"dev": true,
 			"requires": {
 				"@onflow/config": "0.0.2",
-				"@onflow/fcl": "^0.0.77",
+				"@onflow/fcl": "^0.0.78",
 				"@onflow/types": "^0.0.6",
+				"elliptic": "^6.5.4",
 				"esm": "^3.2.25",
 				"handlebars": "^4.7.7",
 				"handlebars-loader": "^1.7.1",
 				"prettier": "^2.3.0",
 				"rimraf": "^3.0.2",
+				"rlp": "^3.0.0",
+				"sha3": "^2.1.4",
 				"simple-git": "^2.40.0",
 				"yargs": "^15.4.1"
 			},
 			"dependencies": {
+				"@onflow/fcl": {
+					"version": "0.0.78",
+					"resolved": "https://registry.npmjs.org/@onflow/fcl/-/fcl-0.0.78.tgz",
+					"integrity": "sha512-zWtzCjG2URWXLblSsXiSKr3qBroq2BSVGsZrWeosbmup/03fb/MJ10w3ECF83Cd2m/M0TevSSp+hcpdBVLZSfw==",
+					"dev": true,
+					"requires": {
+						"@onflow/interaction": "0.0.11",
+						"@onflow/rlp": "0.0.3",
+						"@onflow/sdk": "0.0.56",
+						"@onflow/types": "0.0.6",
+						"@onflow/util-actor": "0.0.2",
+						"@onflow/util-address": "0.0.0",
+						"@onflow/util-invariant": "0.0.0",
+						"@onflow/util-template": "0.0.1",
+						"@onflow/util-uid": "0.0.1"
+					}
+				},
+				"@onflow/sdk": {
+					"version": "0.0.56",
+					"resolved": "https://registry.npmjs.org/@onflow/sdk/-/sdk-0.0.56.tgz",
+					"integrity": "sha512-yYOE+5Tvgprqo01vSxIgYTu4fO6sDFfyueVYFgzXx/F0fdHqy0zfAq+gEVjtWG+LvVD/YvR8eRbcBpfvXu1USA==",
+					"dev": true,
+					"requires": {
+						"@improbable-eng/grpc-web": "^0.14.0",
+						"@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
+						"@onflow/protobuf": "^0.1.8",
+						"@onflow/rlp": "^0.0.3",
+						"@onflow/util-actor": "0.0.2",
+						"@onflow/util-address": "^0.0.0",
+						"@onflow/util-invariant": "^0.0.0",
+						"@onflow/util-template": "0.0.1",
+						"deepmerge": "^4.2.2",
+						"sha3": "^2.1.4"
+					}
+				},
 				"@onflow/types": {
 					"version": "0.0.6",
 					"resolved": "https://registry.npmjs.org/@onflow/types/-/types-0.0.6.tgz",
@@ -15782,6 +16044,12 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"rlp": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/rlp/-/rlp-3.0.0.tgz",
+					"integrity": "sha512-PD6U2PGk6Vq2spfgiWZdomLvRGDreBLxi5jv5M8EpRo3pU6VEm31KO+HFxE18Q3vgqfDrQ9pZA3FP95rkijNKw==",
 					"dev": true
 				},
 				"wrap-ansi": {
@@ -15832,90 +16100,6 @@
 				}
 			}
 		},
-		"flow-js-testing": {
-			"version": "0.2.3-alpha.4",
-			"resolved": "https://registry.npmjs.org/flow-js-testing/-/flow-js-testing-0.2.3-alpha.4.tgz",
-			"integrity": "sha512-dQQYlQnaCdZH6HUZGVp+zTUHAw57SZJB6hy0miBSTqAjxf2/+dE22n4EnMddSm8M7hsgcD/My1ugjvYzMk+GDw==",
-			"dev": true,
-			"requires": {
-				"@onflow/config": "^0.0.2",
-				"@onflow/fcl": "^0.0.78",
-				"@onflow/fcl-config": "^0.0.1",
-				"@onflow/types": "^0.0.6",
-				"elliptic": "^6.5.4",
-				"esm": "^3.2.25",
-				"flow-cadut": "^0.1.15-alpha.12",
-				"jest-environment-uint8array": "^1.0.0",
-				"rimraf": "^3.0.2",
-				"rlp": "^2.2.6",
-				"sha3": "^2.1.4",
-				"yargs": "^17.0.1"
-			},
-			"dependencies": {
-				"@onflow/fcl": {
-					"version": "0.0.78",
-					"resolved": "https://registry.npmjs.org/@onflow/fcl/-/fcl-0.0.78.tgz",
-					"integrity": "sha512-zWtzCjG2URWXLblSsXiSKr3qBroq2BSVGsZrWeosbmup/03fb/MJ10w3ECF83Cd2m/M0TevSSp+hcpdBVLZSfw==",
-					"dev": true,
-					"requires": {
-						"@onflow/interaction": "0.0.11",
-						"@onflow/rlp": "0.0.3",
-						"@onflow/sdk": "0.0.56",
-						"@onflow/types": "0.0.6",
-						"@onflow/util-actor": "0.0.2",
-						"@onflow/util-address": "0.0.0",
-						"@onflow/util-invariant": "0.0.0",
-						"@onflow/util-template": "0.0.1",
-						"@onflow/util-uid": "0.0.1"
-					}
-				},
-				"@onflow/sdk": {
-					"version": "0.0.56",
-					"resolved": "https://registry.npmjs.org/@onflow/sdk/-/sdk-0.0.56.tgz",
-					"integrity": "sha512-yYOE+5Tvgprqo01vSxIgYTu4fO6sDFfyueVYFgzXx/F0fdHqy0zfAq+gEVjtWG+LvVD/YvR8eRbcBpfvXu1USA==",
-					"dev": true,
-					"requires": {
-						"@improbable-eng/grpc-web": "^0.14.0",
-						"@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
-						"@onflow/protobuf": "^0.1.8",
-						"@onflow/rlp": "^0.0.3",
-						"@onflow/util-actor": "0.0.2",
-						"@onflow/util-address": "^0.0.0",
-						"@onflow/util-invariant": "^0.0.0",
-						"@onflow/util-template": "0.0.1",
-						"deepmerge": "^4.2.2",
-						"sha3": "^2.1.4"
-					}
-				},
-				"@onflow/types": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/@onflow/types/-/types-0.0.6.tgz",
-					"integrity": "sha512-2eBrmqiFO37EUOJvzksygP8Wu6lL/m9az36AF0qYdGQW/79KGCHBCchUsIzxyGt8UDXl/dgnIcMkiTH7tWZqXg==",
-					"dev": true
-				},
-				"yargs": {
-					"version": "17.3.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-					"integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
-					"dev": true,
-					"requires": {
-						"cliui": "^7.0.2",
-						"escalade": "^3.1.1",
-						"get-caller-file": "^2.0.5",
-						"require-directory": "^2.1.1",
-						"string-width": "^4.2.3",
-						"y18n": "^5.0.5",
-						"yargs-parser": "^21.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "21.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-					"integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
-					"dev": true
-				}
-			}
-		},
 		"for-each": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -15928,7 +16112,7 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
 			"dev": true
 		},
 		"form-data": {
@@ -15945,7 +16129,7 @@
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
 			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
@@ -15967,6 +16151,17 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"function.prototype.name": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0",
+				"functions-have-names": "^1.2.2"
+			}
 		},
 		"functions-have-names": {
 			"version": "1.2.2",
@@ -16017,7 +16212,7 @@
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
 			"dev": true
 		},
 		"glob": {
@@ -16101,12 +16296,12 @@
 			}
 		},
 		"handlebars-loader": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/handlebars-loader/-/handlebars-loader-1.7.1.tgz",
-			"integrity": "sha512-Q+Z/hDPQzU8ZTlVnAe/0T1LHABlyhL7opNcSKcQDhmUXK2ByGTqib1Z2Tfv4Ic50WqDcLFWQcOb3mhjcBRbscQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/handlebars-loader/-/handlebars-loader-1.7.2.tgz",
+			"integrity": "sha512-rEzru8REzqeJlbotJD+gPQ8AHyxcAjeXbGqGmrz3+sbjecI0ungieONwMR27Htr+AoKI5W36oPLwcwGrPzO8gw==",
 			"dev": true,
 			"requires": {
-				"async": "~0.2.10",
+				"async": "^3.2.2",
 				"fastparse": "^1.0.0",
 				"loader-utils": "1.0.x",
 				"object-assign": "^4.1.0"
@@ -16121,9 +16316,9 @@
 			}
 		},
 		"has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -16131,10 +16326,18 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
+		"has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"requires": {
+				"get-intrinsic": "^1.1.1"
+			}
+		},
 		"has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
 		},
 		"has-tostringtag": {
 			"version": "1.0.0",
@@ -16147,7 +16350,7 @@
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
 			"dev": true,
 			"requires": {
 				"get-value": "^2.0.6",
@@ -16158,7 +16361,7 @@
 		"has-values": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
 			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
@@ -16168,7 +16371,7 @@
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
 					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
@@ -16189,7 +16392,7 @@
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
 			"dev": true,
 			"requires": {
 				"hash.js": "^1.0.3",
@@ -16412,7 +16615,7 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true
 		},
 		"is-bigint": {
@@ -16533,14 +16736,14 @@
 			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
 		},
 		"is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
 		},
 		"is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
@@ -16549,7 +16752,7 @@
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
@@ -16558,9 +16761,9 @@
 			}
 		},
 		"is-number-object": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-			"integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
@@ -16600,9 +16803,12 @@
 			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
 		},
 		"is-shared-array-buffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+			"requires": {
+				"call-bind": "^1.0.2"
+			}
 		},
 		"is-stream": {
 			"version": "2.0.0",
@@ -16638,11 +16844,11 @@
 			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
 		},
 		"is-weakref": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			}
 		},
 		"is-windows": {
@@ -16654,7 +16860,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true
 		},
 		"isexe": {
@@ -16666,7 +16872,7 @@
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
@@ -17516,7 +17722,7 @@
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
 					"dev": true
 				},
 				"slash": {
@@ -18585,7 +18791,7 @@
 		"load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -18597,7 +18803,7 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
 					"dev": true
 				}
 			}
@@ -18605,7 +18811,7 @@
 		"loader-utils": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.4.tgz",
-			"integrity": "sha1-E/Vhl/FSOjBYkSSLTHJEVAhIQmw=",
+			"integrity": "sha512-TMS4PQ0+m0xyRGBunvDQIdhWJY6JOYeEPpHZEW0EmDhqKrQUj04xiMT3jsdVS17pUg0JzX1mJI3QiV8lXjoEng==",
 			"dev": true,
 			"requires": {
 				"big.js": "^3.1.3",
@@ -18616,7 +18822,7 @@
 				"json5": {
 					"version": "0.5.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+					"integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
 					"dev": true
 				}
 			}
@@ -18755,13 +18961,13 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
 			"dev": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
 			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
@@ -18865,7 +19071,7 @@
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
 			"dev": true
 		},
 		"minimatch": {
@@ -18877,9 +19083,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
 		},
 		"mixin-deep": {
 			"version": "1.3.2",
@@ -18892,12 +19098,12 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			}
 		},
 		"ms": {
@@ -18923,9 +19129,9 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
 		},
 		"nan": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-			"integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+			"integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
 			"dev": true,
 			"optional": true
 		},
@@ -19196,13 +19402,13 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
 			"dev": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
@@ -19213,7 +19419,7 @@
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
 					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
@@ -19222,7 +19428,7 @@
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -19231,7 +19437,7 @@
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -19259,7 +19465,7 @@
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
@@ -19268,9 +19474,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -19280,7 +19486,7 @@
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
@@ -19298,20 +19504,21 @@
 			}
 		},
 		"object.getownpropertydescriptors": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz",
-			"integrity": "sha512-VdDoCwvJI4QdC6ndjpqFmoL3/+HxffFBbcJzKi5hwLLqqx3mdbedRpfZDdK0SrOSauj8X4GzBvnDZl4vTN7dOw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.4.tgz",
+			"integrity": "sha512-sccv3L/pMModT6dJAYF3fzGMVcb38ysQ0tEE6ixv2yXJDtEIPph268OlAdJj5/qZMZDq2g/jqvwppt36uS/uQQ==",
 			"dev": true,
 			"requires": {
+				"array.prototype.reduce": "^1.0.4",
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.1"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.1"
 			}
 		},
 		"object.pick": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
@@ -19428,7 +19635,7 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
 			"dev": true
 		},
 		"p-limit": {
@@ -19463,7 +19670,7 @@
 		"parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
 			"dev": true,
 			"requires": {
 				"error-ex": "^1.3.1",
@@ -19479,7 +19686,7 @@
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
 			"dev": true
 		},
 		"path-exists": {
@@ -19531,7 +19738,7 @@
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
 			"dev": true
 		},
 		"pirates": {
@@ -19554,7 +19761,7 @@
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
 			"dev": true
 		},
 		"postcss": {
@@ -19672,7 +19879,7 @@
 		"read-pkg": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
 			"dev": true,
 			"requires": {
 				"load-json-file": "^4.0.0",
@@ -19721,7 +19928,7 @@
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
 					"dev": true
 				}
 			}
@@ -19798,6 +20005,16 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regexp.prototype.flags": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+			"integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"functions-have-names": "^1.2.2"
+			}
+		},
 		"regexpu-core": {
 			"version": "4.7.1",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
@@ -19843,7 +20060,7 @@
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
 			"dev": true
 		},
 		"repeat-element": {
@@ -19855,7 +20072,7 @@
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
 			"dev": true
 		},
 		"require-directory": {
@@ -19897,7 +20114,7 @@
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
 			"dev": true
 		},
 		"restore-cursor": {
@@ -19939,9 +20156,9 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-					"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+					"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
 					"dev": true
 				}
 			}
@@ -19989,7 +20206,7 @@
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
 			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
@@ -20057,7 +20274,7 @@
 				"is-stream": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+					"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
 					"dev": true
 				},
 				"micromatch": {
@@ -20084,7 +20301,7 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
 					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
@@ -20093,7 +20310,7 @@
 				"path-key": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
 					"dev": true
 				},
 				"semver": {
@@ -20105,7 +20322,7 @@
 				"shebang-command": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
 					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
@@ -20114,7 +20331,7 @@
 				"shebang-regex": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
 					"dev": true
 				},
 				"which": {
@@ -20145,7 +20362,7 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
 			"dev": true
 		},
 		"set-value": {
@@ -20163,7 +20380,7 @@
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
@@ -20172,7 +20389,7 @@
 				"is-extendable": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+					"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 					"dev": true
 				}
 			}
@@ -20314,7 +20531,7 @@
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
 					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
@@ -20323,7 +20540,7 @@
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
 					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
@@ -20332,7 +20549,7 @@
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -20341,7 +20558,7 @@
 						"kind-of": {
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
@@ -20352,7 +20569,7 @@
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -20361,7 +20578,7 @@
 						"kind-of": {
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
@@ -20383,7 +20600,7 @@
 				"is-extendable": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+					"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 					"dev": true
 				},
 				"kind-of": {
@@ -20395,7 +20612,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 					"dev": true
 				}
 			}
@@ -20414,7 +20631,7 @@
 				"define-property": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
 					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
@@ -20434,7 +20651,7 @@
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
@@ -20557,7 +20774,7 @@
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
 			"dev": true,
 			"requires": {
 				"define-property": "^0.2.5",
@@ -20567,7 +20784,7 @@
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
 					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
@@ -20576,7 +20793,7 @@
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -20585,7 +20802,7 @@
 						"kind-of": {
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
@@ -20596,7 +20813,7 @@
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -20605,7 +20822,7 @@
 						"kind-of": {
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
@@ -20668,21 +20885,23 @@
 			}
 		},
 		"string.prototype.trimend": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+			"integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+			"integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			}
 		},
 		"strip-ansi": {
@@ -20702,7 +20921,7 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
 			"dev": true
 		},
 		"strip-final-newline": {
@@ -20883,7 +21102,7 @@
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
@@ -20892,7 +21111,7 @@
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
 					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
@@ -20915,7 +21134,7 @@
 		"to-regex-range": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
 			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
@@ -20982,20 +21201,20 @@
 			}
 		},
 		"uglify-js": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-			"integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
+			"integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
 			"dev": true,
 			"optional": true
 		},
 		"unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
 			"requires": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			}
 		},
@@ -21042,7 +21261,7 @@
 				"is-extendable": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+					"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
 					"dev": true
 				}
 			}
@@ -21056,7 +21275,7 @@
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
 			"dev": true,
 			"requires": {
 				"has-value": "^0.3.1",
@@ -21066,7 +21285,7 @@
 				"has-value": {
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
 					"dev": true,
 					"requires": {
 						"get-value": "^2.0.3",
@@ -21077,7 +21296,7 @@
 						"isobject": {
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
 							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
@@ -21088,7 +21307,7 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
 					"dev": true
 				}
 			}
@@ -21096,7 +21315,7 @@
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
 			"dev": true
 		},
 		"use": {
@@ -21290,7 +21509,7 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
 			"dev": true
 		},
 		"word-wrap": {
@@ -21302,7 +21521,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
 			"dev": true
 		},
 		"wrap-ansi": {

--- a/cadence/tests/package.json
+++ b/cadence/tests/package.json
@@ -19,9 +19,9 @@
 	"devDependencies": {
 		"@babel/core": "^7.14.0",
 		"@babel/preset-env": "^7.14.1",
+		"@onflow/flow-js-testing": "^0.3.0-alpha.8",
 		"@onflow/types": "0.0.4",
 		"babel-jest": "^27.0.2",
-		"flow-js-testing": "^0.2.3-alpha.4",
 		"jest": "^27.0.4",
 		"prettier": "^2.3.0"
 	},

--- a/cadence/tests/src/common.js
+++ b/cadence/tests/src/common.js
@@ -1,5 +1,4 @@
-import { getAccountAddress } from "flow-js-testing";
-import { deployContractByName, executeScript, sendTransaction } from "flow-js-testing";
+import { deployContractByName, executeScript, getAccountAddress, sendTransaction } from "@onflow/flow-js-testing";
 
 const UFIX64_PRECISION = 8;
 

--- a/cadence/tests/src/kitty-items.js
+++ b/cadence/tests/src/kitty-items.js
@@ -1,4 +1,4 @@
-import { mintFlow, executeScript, sendTransaction, deployContractByName } from "flow-js-testing";
+import { mintFlow, executeScript, sendTransaction, deployContractByName } from "@onflow/flow-js-testing";
 import { getKittyAdminAddress } from "./common";
 
 export const types = {

--- a/cadence/tests/src/nft-storefront.js
+++ b/cadence/tests/src/nft-storefront.js
@@ -1,4 +1,4 @@
-import { deployContractByName, sendTransaction, executeScript } from "flow-js-testing"
+import { deployContractByName, sendTransaction, executeScript } from "@onflow/flow-js-testing"
 import { getKittyAdminAddress } from "./common";
 import { deployKittyItems, setupKittyItemsOnAccount } from "./kitty-items";
 

--- a/cadence/tests/test/kitty-items.test.js
+++ b/cadence/tests/test/kitty-items.test.js
@@ -7,7 +7,7 @@ import {
 	shallPass,
 	shallResolve,
 	shallRevert,
-} from "flow-js-testing";
+} from "@onflow/flow-js-testing";
 
 import { getKittyAdminAddress } from "../src/common";
 import {
@@ -28,9 +28,8 @@ describe("Kitty Items", () => {
 	// Instantiate emulator and path to Cadence files
 	beforeEach(async () => {
 		const basePath = path.resolve(__dirname, "../../");
-		const port = 7002;
-		await init(basePath, { port });
-		await emulator.start(port, false);
+		await init(basePath);
+		await emulator.start();
 		return await new Promise(r => setTimeout(r, 1000));
 	});
 

--- a/cadence/tests/test/nft-storefront.test.js
+++ b/cadence/tests/test/nft-storefront.test.js
@@ -6,7 +6,7 @@ import {
 	getAccountAddress,
 	shallPass,
 	mintFlow,
-} from "flow-js-testing";
+} from "@onflow/flow-js-testing";
 
 import { toUFix64 } from "../src/common";
 import { 
@@ -31,9 +31,8 @@ jest.setTimeout(500000);
 describe("NFT Storefront", () => {
 	beforeEach(async () => {
 		const basePath = path.resolve(__dirname, "../../");
-		const port = 7003;
-		await init(basePath, { port });
-		await emulator.start(port, false);
+		await init(basePath);
+		await emulator.start();
 		return await new Promise(r => setTimeout(r, 1000));
 	});
 


### PR DESCRIPTION
1. flow-js-testing has been migrated to the @onflow organization (@onflow/flow-js-testing)
2. 0.3.0 introduces dynamic port selection for the emulator and removes the statically supplied ports