### PR TITLE
Run e2e tests on master push

### DIFF
--- a/.github/workflows/integration-local.yml
+++ b/.github/workflows/integration-local.yml
@@ -6,6 +6,7 @@ on:
       - master
   push:
     branches:
+      - master
       - gpavlov/update-github-actions-workflow
       - gpavlov/setup-cypress
 


### PR DESCRIPTION
Updating conditions to run e2e tests. The tests should run when the master branch is updated.