### PR TITLE
Bug Fix - Move the check for env config to after account setup 

### DIFF
--- a/.ki-scripts/startup.js
+++ b/.ki-scripts/startup.js
@@ -434,10 +434,6 @@ pm2.connect(false, async function (err) {
   // ------------- TESTNET ENVIRONMENT STARTUP ------------------
 
   if (process.env.CHAIN_ENV === "testnet") {
-    dotenv.config({
-      path: requireEnv(process.env.CHAIN_ENV),
-    });
-
     // Determine whether the user wants to reuse existing testnet accounts
     let useExisting = false
 
@@ -467,6 +463,9 @@ pm2.connect(false, async function (err) {
     }
 
     // Always redeploy and initialize account because the contracts may have been updated
+    dotenv.config({
+      path: requireEnv(process.env.CHAIN_ENV),
+    });
     await deployAndInitialize();
   }
 


### PR DESCRIPTION
Issue: https://github.com/onflow/kitty-items/issues/300

Bug Cause: This bug was caused by my refactoring in the startup.js testnet setup. The check for the env setup (for testnet, this means checking that the testnet config files exist) was happening before the account creation dialogue, which results in startup failure (since most new users would not have this file pre-configured). This startup path is also the only path not tested during cypress e2e testing - this is because the cypress e2e tests use an existing testnet account and does not require the testnet configuration file for startup. See diff here: https://github.com/onflow/kitty-items/pull/295/files#diff-b6fd80401f711ce5defc777da468bde51d75d7dd5759f2c02769fe19d8d54dbf

Fix: Moving the environment check to the end of the block, which is where it should be. The dialogue (user interaction prompts) is dependent on whether or not the testnet config file exists, so the environment check should not expect the config file to exist before user interaction. This is specific to the first time testnet startup process.

